### PR TITLE
render lyon, text and rounded rect single pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ perf.data.old
 flamegraph.svg
 heaptrack*
 dhat*
+vk_layer_settings.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
+name = "bytemuck"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
+
+[[package]]
 name = "calloop"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +291,28 @@ dependencies = [
  "core-graphics 0.19.2",
  "libc",
  "objc",
+]
+
+[[package]]
+name = "crevice"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0388841c63d751d6444f5ebcf55bc98dde119e2a6547e7acda457cda3b36c55a"
+dependencies = [
+ "bytemuck",
+ "crevice-derive",
+ "mint",
+]
+
+[[package]]
+name = "crevice-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77417e514ad5c6d9ceb5e193c738db439a394ee7e602285feffc8dfc9bda7d0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -858,6 +886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6595bb28ed34f43c3fe088e48f6cfb2e033cab45f25a5384d5fdf564fbc8c4b2"
 
 [[package]]
+name = "mint"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519df8d6856dcd4b40519947737b408f81be051fc032590659cae5d77d664185"
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,6 +945,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "crevice",
  "ctor",
  "dashmap",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ members = [
     "rutter_layout",
     "freelist"
 ]
+
+[features]
+debug_bounds = ["narui_core/debug_bounds"]

--- a/examples/node_graph.rs
+++ b/examples/node_graph.rs
@@ -97,7 +97,7 @@ pub fn handle(
             >
                 <rect_leaf
                     fill=Some(color)
-                    border_radius=Paxel(size)
+                    border_radius=Fraction(1.0)
                 />
             </drag_detector>
         </sized>

--- a/examples/renderobject_delta.rs
+++ b/examples/renderobject_delta.rs
@@ -7,9 +7,9 @@ pub fn top(context: &mut WidgetContext) -> Fragment {
         context.shout(frame_counter, context.spy(frame_counter) + 1);
     });
     let border_radius = ((context.listen(frame_counter) as f32 / 50.0).sin() + 1.0) / 4.0;
-
+    let stroke_width = ((context.listen(frame_counter) as f32 / 30.0).sin() + 1.0) * 50.0;
     rsx! {
-        <rect_leaf fill=Some(Color::new(1., 0., 0., 1.)) border_radius=Fraction(border_radius)>
+        <rect_leaf stroke=Some((Color::new(0., 1., 0., 1.), stroke_width)) fill=Some(Color::new(1., 0., 0., 1.)) border_radius=Fraction(border_radius)>
         </rect_leaf>
     }
 }

--- a/narui_core/Cargo.toml
+++ b/narui_core/Cargo.toml
@@ -36,6 +36,7 @@ ordered-float = "2.1.1"
 smallvec = "1.6.1"
 take_mut = "0.2.2"
 tinyset = "0.4.6"
+crevice = "0.7.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemallocator = "0.3.2"

--- a/narui_core/src/context/context.rs
+++ b/narui_core/src/context/context.rs
@@ -157,7 +157,7 @@ impl FragmentStore {
         self.data[idx.0].args = Some(args);
     }
 
-    pub fn dirty_args<'a>(&'a mut self) -> impl Iterator<Item = Fragment> + 'a {
+    pub fn dirty_args(&'_ mut self) -> impl Iterator<Item = Fragment> + '_ {
         self.dirty_args.drain(..).rev()
     }
 }

--- a/narui_core/src/context/patched_tree.rs
+++ b/narui_core/src/context/patched_tree.rs
@@ -130,7 +130,7 @@ impl PatchedTree {
         self.data.write()[key.1].0.insert(frag.0.get());
     }
 
-    pub fn dependents<'a>(&'a self, key: HookRef) -> impl Iterator<Item = Fragment> + 'a {
+    pub fn dependents(&'_ self, key: HookRef) -> impl Iterator<Item = Fragment> + '_ {
         std::mem::take(&mut self.data.write()[key.1].0)
             .into_iter()
             .map(|v| Fragment(unsafe { NonZeroUsize::new_unchecked(v) }))

--- a/narui_core/src/eval/fragment.rs
+++ b/narui_core/src/eval/fragment.rs
@@ -3,6 +3,7 @@ use crate::{
     vulkano_render::lyon_render::ColoredBuffersBuilder,
     CallbackContext,
     Color,
+    Dimension,
     Key,
     WidgetContext,
 };
@@ -100,6 +101,13 @@ pub type RenderFnInner = dyn Fn(
 #[derivative(Debug)]
 pub enum RenderObject {
     DebugRect,
+    RoundedRect {
+        inverted: bool,
+        stroke_color: Option<Color>,
+        fill_color: Option<Color>,
+        stroke_width: f32,
+        border_radius: Dimension,
+    },
     Path {
         #[derivative(Debug = "ignore")]
         path_gen: Arc<PathGenInner>,

--- a/narui_core/src/util/geom.rs
+++ b/narui_core/src/util/geom.rs
@@ -8,6 +8,11 @@ pub struct Vec2 {
     pub x: f32,
     pub y: f32,
 }
+
+impl From<Vec2> for crevice::std430::Vec2 {
+    fn from(vec2: Vec2) -> crevice::std430::Vec2 { crevice::std430::Vec2 { x: vec2.x, y: vec2.y } }
+}
+
 impl Vec2 {
     pub fn zero() -> Self { Vec2 { x: 0.0, y: 0.0 } }
     pub fn new(x: f32, y: f32) -> Self { Vec2 { x, y } }
@@ -19,6 +24,7 @@ impl Vec2 {
     }
     pub fn with_x(&self, x: f32) -> Self { Self { x, ..*self } }
     pub fn with_y(&self, y: f32) -> Self { Self { y, ..*self } }
+    pub fn maximum(&self) -> f32 { self.x.max(self.y) }
 }
 impl Add for Vec2 {
     type Output = Vec2;
@@ -148,5 +154,9 @@ impl Rect {
                 self.far_corner().y.min(clipper.far_corner().y),
             ),
         )
+    }
+    pub fn center(&self) -> Vec2 { self.pos + self.size / 2.0 }
+    pub fn inset(&self, val: f32) -> Self {
+        Self { pos: self.pos + val, size: self.size - 2.0 * val }
     }
 }

--- a/narui_core/src/vulkano_render/lyon_render.rs
+++ b/narui_core/src/vulkano_render/lyon_render.rs
@@ -1,191 +1,137 @@
-use super::vk_util::VulkanContext;
-use crate::{eval::layout::PositionedRenderObject, geom::Vec2, Color, RenderObject};
+use crate::{
+    eval::layout::PositionedRenderObject,
+    geom::Vec2,
+    re_export::lyon::lyon_tessellation::{Count, GeometryBuilderError, VertexId},
+    vulkano_render::renderer::RenderData,
+    Color,
+    RenderObject,
+};
 use lyon::{
-    lyon_tessellation::{
-        BuffersBuilder,
-        FillTessellator,
-        FillVertex,
-        StrokeVertexConstructor,
-        VertexBuffers,
+    lyon_tessellation::{FillTessellator, FillVertex},
+    tessellation::{
+        FillGeometryBuilder,
+        GeometryBuilder,
+        StrokeGeometryBuilder,
+        StrokeTessellator,
+        StrokeVertex,
     },
-    tessellation::{FillVertexConstructor, StrokeOptions, StrokeTessellator, StrokeVertex},
 };
 use palette::Pixel;
-use std::sync::Arc;
-use vulkano::{
-    buffer::{BufferUsage, CpuAccessibleBuffer},
-    command_buffer::{AutoCommandBufferBuilder, DynamicState, PrimaryAutoCommandBuffer},
-    device::Device,
-    pipeline::{
-        depth_stencil::{Compare, DepthStencil},
-        vertex::BuffersDefinition,
-        GraphicsPipeline,
-    },
-    render_pass::{RenderPass, Subpass},
-};
 
-
-mod vertex_shader {
-    vulkano_shaders::shader! {
-        ty: "vertex",
-        src: "
-            #version 450
-            layout(push_constant) uniform PushConstantData {
-                uint width;
-                uint height;
-            } params;
-            layout(location = 0) in vec3 position;
-            layout(location = 1) in vec4 color;
-            layout(location = 2) in vec2 clip_min;
-            layout(location = 3) in vec2 clip_max;
-            layout(location = 0) out vec4 color_frag;
-            layout(location = 1) out vec2 clip_min_out;
-            layout(location = 2) out vec2 clip_max_out;
-            void main() {
-                color_frag = color;
-                clip_min_out = clip_min;
-                clip_max_out = clip_max;
-
-                vec2 zero_to_one = position.xy / vec2(params.width, params.height);
-                gl_Position = vec4(vec2(zero_to_one * 2. - vec2(1.)), position.z, 1.0);
-            }
-        "
-    }
-}
-mod fragment_shader {
-    vulkano_shaders::shader! {
-        ty: "fragment",
-        src: "
-            #version 450
-            layout(location = 0) in vec4 color_frag;
-            layout(location = 1) in vec2 clip_min;
-            layout(location = 2) in vec2 clip_max;
-            layout(location = 0) out vec4 f_color;
-
-            void main() {
-                if (gl_FragCoord.x < clip_min.x || gl_FragCoord.y < clip_min.y
-                 || gl_FragCoord.x > clip_max.x || gl_FragCoord.y > clip_max.y) {
-                    discard;
-                }
-
-                f_color = color_frag;
-            }
-        "
-    }
-}
-
-#[derive(Default, Debug, Clone)]
-pub struct Vertex {
-    position: [f32; 3],
-    color: [f32; 4],
-    clip_min: [f32; 2],
-    clip_max: [f32; 2],
-}
-vulkano::impl_vertex!(Vertex, position, color, clip_min, clip_max);
-
-#[derive(Default)]
-pub struct LyonRendererState(VertexBuffers<Vertex, u32>);
 
 pub struct ColoredBuffersBuilder<'a> {
-    vertex_buffers: &'a mut VertexBuffers<Vertex, u32>,
+    data: &'a mut RenderData,
     pos: Vec2,
     z_index: f32,
     clip_min: [f32; 2],
     clip_max: [f32; 2],
 }
 impl<'a> ColoredBuffersBuilder<'a> {
-    pub fn with_color(
-        &mut self,
-        color: Color,
-    ) -> BuffersBuilder<Vertex, u32, PositionedColoredConstructor> {
-        BuffersBuilder::new(
-            &mut self.vertex_buffers,
-            PositionedColoredConstructor {
-                position: self.pos,
-                color: color.into_raw::<[f32; 4]>(),
-                z_index: self.z_index,
-                clip_min: self.clip_min,
-                clip_max: self.clip_max,
-            },
+    pub fn with_color(&mut self, color: Color) -> NaruiGeometryBuilder {
+        NaruiGeometryBuilder::new(
+            self.data,
+            self.pos,
+            self.z_index,
+            color.into_raw::<[f32; 4]>(),
+            self.clip_min,
+            self.clip_max,
         )
     }
 }
 
-pub struct PositionedColoredConstructor {
+pub struct NaruiGeometryBuilder<'a> {
+    primitive_index: u32,
     position: Vec2,
-    color: [f32; 4],
-    z_index: f32,
-    clip_min: [f32; 2],
-    clip_max: [f32; 2],
+    data: &'a mut RenderData,
+    vertex_offset: u32,
+    index_offset: u32,
 }
-impl FillVertexConstructor<Vertex> for PositionedColoredConstructor {
-    fn new_vertex(&mut self, vertex: FillVertex) -> Vertex {
-        let pos: Vec2 = vertex.position().into();
-        let pos = pos + self.position;
-        Vertex {
-            position: [pos.x, pos.y, self.z_index],
-            color: self.color,
-            clip_min: self.clip_min,
-            clip_max: self.clip_max,
-        }
-    }
-}
-impl StrokeVertexConstructor<Vertex> for PositionedColoredConstructor {
-    fn new_vertex(&mut self, vertex: StrokeVertex) -> Vertex {
-        let pos: Vec2 = vertex.position().into();
-        let pos = pos + self.position;
-        Vertex {
-            position: [pos.x, pos.y, self.z_index],
-            color: self.color,
-            clip_min: self.clip_min,
-            clip_max: self.clip_max,
+
+impl<'a> NaruiGeometryBuilder<'a> {
+    fn new(
+        data: &'a mut RenderData,
+        position: Vec2,
+        z_index: f32,
+        color: [f32; 4],
+        clip_min: [f32; 2],
+        clip_max: [f32; 2],
+    ) -> Self {
+        Self {
+            primitive_index: data.add_lyon_data(color, z_index, clip_min, clip_max),
+            position,
+            data,
+            vertex_offset: 0,
+            index_offset: 0,
         }
     }
 }
 
+impl<'a> GeometryBuilder for NaruiGeometryBuilder<'a> {
+    fn begin_geometry(&mut self) {
+        self.vertex_offset = self.data.vertices.len() as _;
+        self.index_offset = self.data.indices.len() as _;
+    }
+
+    fn end_geometry(&mut self) -> Count {
+        Count {
+            vertices: self.data.vertices.len() as u32 - self.vertex_offset,
+            indices: self.data.indices.len() as u32 - self.index_offset,
+        }
+    }
+
+    fn add_triangle(&mut self, a: VertexId, b: VertexId, c: VertexId) {
+        self.data.indices.push(a.0);
+        self.data.indices.push(b.0);
+        self.data.indices.push(c.0);
+    }
+
+    fn abort_geometry(&mut self) {
+        self.data.vertices.truncate(self.vertex_offset as usize);
+        self.data.indices.truncate(self.index_offset as usize);
+    }
+}
+
+impl<'a> FillGeometryBuilder for NaruiGeometryBuilder<'a> {
+    fn add_fill_vertex(&mut self, vertex: FillVertex) -> Result<VertexId, GeometryBuilderError> {
+        Ok(self
+            .data
+            .add_lyon_vertex(
+                self.primitive_index,
+                [self.position.x + vertex.position().x, self.position.y + vertex.position().y],
+            )
+            .into())
+    }
+}
+
+impl<'a> StrokeGeometryBuilder for NaruiGeometryBuilder<'a> {
+    fn add_stroke_vertex(
+        &mut self,
+        vertex: StrokeVertex,
+    ) -> Result<VertexId, GeometryBuilderError> {
+        Ok(self
+            .data
+            .add_lyon_vertex(
+                self.primitive_index,
+                [self.position.x + vertex.position().x, self.position.y + vertex.position().y],
+            )
+            .into())
+    }
+}
 
 pub struct LyonRenderer {
-    device: Arc<Device>,
-    pipeline: Arc<GraphicsPipeline<BuffersDefinition>>,
     fill_tessellator: FillTessellator,
     stroke_tessellator: StrokeTessellator,
 }
 impl LyonRenderer {
-    pub fn new(render_pass: Arc<RenderPass>) -> Self {
-        let device = VulkanContext::get().device;
-
-        let vs = vertex_shader::Shader::load(device.clone()).unwrap();
-        let fs = fragment_shader::Shader::load(device.clone()).unwrap();
-
-        let pipeline = Arc::new(
-            GraphicsPipeline::start()
-                .vertex_input_single_buffer::<Vertex>()
-                .vertex_shader(vs.main_entry_point(), ())
-                .triangle_list()
-                .viewports_dynamic_scissors_irrelevant(1)
-                .fragment_shader(fs.main_entry_point(), ())
-                .blend_alpha_blending()
-                .depth_stencil(DepthStencil {
-                    depth_compare: Compare::LessOrEqual,
-                    ..DepthStencil::simple_depth_test()
-                })
-                .render_pass(Subpass::from(render_pass, 0).unwrap())
-                .build(device.clone())
-                .unwrap(),
-        );
-
+    pub fn new() -> Self {
         Self {
-            pipeline,
-            device,
-
             fill_tessellator: FillTessellator::new(),
             stroke_tessellator: StrokeTessellator::new(),
         }
     }
-    pub fn begin(&self) -> LyonRendererState { Default::default() }
     pub fn render<'a>(
         &mut self,
-        state: &mut LyonRendererState,
+        data: &mut RenderData,
         render_object: &PositionedRenderObject<'a>,
     ) {
         let clipping_rect = if let Some(clipping_rect) = render_object.clipping_rect {
@@ -194,76 +140,19 @@ impl LyonRenderer {
             render_object.rect
         };
 
-        let LyonRendererState(vertex_buffers) = state;
-        match render_object.render_object {
-            RenderObject::Path { path_gen } => {
-                (path_gen)(
-                    render_object.rect.size,
-                    &mut self.fill_tessellator,
-                    &mut self.stroke_tessellator,
-                    ColoredBuffersBuilder {
-                        vertex_buffers,
-                        pos: render_object.rect.pos,
-                        z_index: 1.0 - render_object.z_index as f32 / 65535.0,
-                        clip_min: clipping_rect.near_corner().into(),
-                        clip_max: clipping_rect.far_corner().into(),
-                    },
-                );
-            }
-            RenderObject::DebugRect => {
-                let r = render_object.rect;
-                self.stroke_tessellator
-                    .tessellate_rectangle(
-                        &lyon::math::rect(0.0, 0.0, r.size.x, r.size.y),
-                        &StrokeOptions::default().with_line_width(2.0),
-                        &mut ColoredBuffersBuilder {
-                            vertex_buffers,
-                            pos: render_object.rect.pos,
-                            z_index: 0.0,
-                            clip_min: [0., 0.],
-                            clip_max: [10000., 10000.],
-                        }
-                        .with_color(Color::new(1.0, 0.0, 0.0, 0.25)),
-                    )
-                    .unwrap();
-            }
-            _ => {}
+        if let RenderObject::Path { path_gen } = render_object.render_object {
+            (path_gen)(
+                render_object.rect.size,
+                &mut self.fill_tessellator,
+                &mut self.stroke_tessellator,
+                ColoredBuffersBuilder {
+                    data,
+                    pos: render_object.rect.pos,
+                    z_index: 1.0 - render_object.z_index as f32 / 65535.0,
+                    clip_min: clipping_rect.near_corner().into(),
+                    clip_max: clipping_rect.far_corner().into(),
+                },
+            );
         };
-    }
-    pub fn finish(
-        &mut self,
-        state: LyonRendererState,
-        buffer_builder: &mut AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>,
-        dynamic_state: &DynamicState,
-        dimensions: &[u32; 2],
-    ) {
-        let vertex_buffer = CpuAccessibleBuffer::<[Vertex]>::from_iter(
-            self.device.clone(),
-            BufferUsage::all(),
-            false,
-            state.0.vertices.into_iter(),
-        )
-        .unwrap();
-
-        let index_buffer = CpuAccessibleBuffer::<[u32]>::from_iter(
-            self.device.clone(),
-            BufferUsage::all(),
-            false,
-            state.0.indices.into_iter(),
-        )
-        .unwrap();
-
-        let push_constants =
-            vertex_shader::ty::PushConstantData { width: dimensions[0], height: dimensions[1] };
-        buffer_builder
-            .draw_indexed(
-                self.pipeline.clone(),
-                dynamic_state,
-                vertex_buffer,
-                index_buffer,
-                (),
-                push_constants,
-            )
-            .unwrap();
     }
 }

--- a/narui_core/src/vulkano_render/mod.rs
+++ b/narui_core/src/vulkano_render/mod.rs
@@ -2,5 +2,25 @@ mod input_handler;
 pub(crate) mod lyon_render;
 pub mod raw_render;
 pub(crate) mod render;
+pub(crate) mod renderer;
 pub(crate) mod text_render;
 pub(crate) mod vk_util;
+
+
+// general idea:
+// render as indexed triangle list (strip is not possible because lyon only
+// emits a triangle list) the vertex data is just position
+// additionally use a shader buffer object for per primitive data,
+// per primitive data:
+// vec4 fill_color;
+// vec4 stroke_color;
+// float z_index;
+// for text rendering
+// vec2 tex_base;
+// vec2 tex_scale;
+// for rect rendering
+// vec2 center;
+// vec2 size;
+// float border_radius;
+// float stroke_width;
+// u8 type;

--- a/narui_core/src/vulkano_render/renderer.rs
+++ b/narui_core/src/vulkano_render/renderer.rs
@@ -1,0 +1,449 @@
+use crate::{eval::layout::PositionedRenderObject, geom::Rect, Dimension, RenderObject, Vec2};
+use crevice::std430::AsStd430;
+
+
+use palette::Pixel;
+use std::sync::Arc;
+use vulkano::{
+    buffer::{BufferUsage, ImmutableBuffer},
+    command_buffer::{AutoCommandBufferBuilder, DynamicState, PrimaryAutoCommandBuffer},
+    descriptor_set::persistent::PersistentDescriptorSet,
+    device::{Device, Queue},
+    image::{view::ImageView, ImmutableImage},
+    pipeline::{
+        depth_stencil::{Compare, DepthStencil},
+        vertex::BuffersDefinition,
+        GraphicsPipeline,
+        GraphicsPipelineAbstract,
+    },
+    render_pass::{RenderPass, Subpass},
+    sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode},
+    sync::GpuFuture,
+};
+
+mod vertex_shader {
+    vulkano_shaders::shader! {
+        ty: "vertex",
+        src: "
+            #version 450
+            #extension GL_EXT_debug_printf: enable
+            layout(push_constant) uniform PushConstantData {
+                uint width;
+                uint height;
+            } params;
+
+            struct PerPrimitiveData {
+                uint ty;
+                float z_index;
+                vec2 base_or_center;
+                vec4 color;
+                vec2 tex_base_or_half_size;
+                vec2 tex_scale_or_border_radius_and_stroke_width;
+                vec2 clip_min;
+                vec2 clip_max;
+            };
+
+            layout(set = 0, binding = 0, std430) buffer readonly PrimitiveData { PerPrimitiveData data[]; } primitive_data;
+            layout(location = 0) in vec2 pos;
+            layout(location = 1) in uint primitive_index;
+
+            layout(location = 0) out vec2 tex_or_rel_pos;
+            layout(location = 1) out vec2 half_size;
+            layout(location = 2) out vec4 color;
+            layout(location = 3) out uint ty;
+            layout(location = 4) out float inverted;
+            layout(location = 5) out float border_radius;
+            layout(location = 6) out float stroke_width;
+            layout(location = 7) out vec2 clip_min;
+            layout(location = 8) out vec2 clip_max;
+
+            void main() {
+                PerPrimitiveData data = primitive_data.data[primitive_index];
+                color = data.color;
+                ty = data.ty;
+                // debugPrintfEXT(\"pos = %f, %f, %f, color = %f, %f, %f, %f\", pos.x, pos.y, data.z_index, color.x, color.y, color.z, color.w);
+                border_radius = data.tex_scale_or_border_radius_and_stroke_width.x;
+                stroke_width = data.tex_scale_or_border_radius_and_stroke_width.y;
+                half_size = data.tex_base_or_half_size;
+                tex_or_rel_pos = vec2(0.0);
+                clip_min = data.clip_min;
+                clip_max = data.clip_max;
+                inverted = float(ty == 3);
+
+                // 0 is lyon
+                // 1 is text
+                // 2 is rounded rect
+                if (ty == 1) {
+                    tex_or_rel_pos = ((pos - data.base_or_center) * data.tex_scale_or_border_radius_and_stroke_width) + data.tex_base_or_half_size;
+                } else if ((ty == 2) || (ty == 3)) {
+                    tex_or_rel_pos = (pos - data.base_or_center);
+                }
+
+                gl_Position = vec4((pos / (vec2(params.width, params.height) / 2.) - vec2(1.)), data.z_index, 1.0);
+            }
+        "
+    }
+}
+mod fragment_shader {
+    vulkano_shaders::shader! {
+        ty: "fragment",
+        src: "
+            #version 450
+            #extension GL_EXT_debug_printf: enable
+            layout(set = 0, binding = 1) uniform sampler2D tex;
+            layout(location = 0) in vec2 tex_or_rel_pos;
+            layout(location = 1) flat in vec2 half_size;
+            layout(location = 2) flat in vec4 color;
+            layout(location = 3) flat in uint ty;
+            layout(location = 4) flat in float inverted;
+            layout(location = 5) flat in float border_radius;
+            layout(location = 6) flat in float stroke_width;
+            layout(location = 7) flat in vec2 clip_min;
+            layout(location = 8) flat in vec2 clip_max;
+
+            layout(location = 0) out vec4 f_color;
+
+            void main() {
+                if (gl_FragCoord.x < clip_min.x || gl_FragCoord.y < clip_min.y
+                 || gl_FragCoord.x > clip_max.x || gl_FragCoord.y > clip_max.y) {
+                    discard;
+                } else {
+                    if (ty == 0) { // lyon
+                        f_color = color;
+                    } else if (ty == 1) { // text
+                        float alpha = texture(tex, tex_or_rel_pos).r;
+                        f_color = color;
+                        f_color.a *= alpha;
+                    } else { // rounded rect
+                        vec2 abs_pos = abs(tex_or_rel_pos) - half_size;
+                        float inner_radius = max(border_radius - stroke_width, 0.0);
+                        vec2 outer_pos = abs_pos + border_radius;
+                        vec2 inner_pos = abs_pos + stroke_width + inner_radius;
+                        float outer = length(max(outer_pos, 0.0)) + min(max(outer_pos.x, outer_pos.y), 0.0);
+                        float inner = length(max(inner_pos, 0.0)) + min(max(inner_pos.x, inner_pos.y), 0.0);
+                        float from_outer = clamp(0.5 - (outer - border_radius), 0, 1);
+                        float from_inner = clamp(0.5 - (inner_radius - inner), 0, 1);
+                        float rect_alpha = abs(float(inverted) - from_outer * from_inner);
+                        float alpha = color.a * rect_alpha;
+                        if (rect_alpha == 0.0) discard;
+                        f_color = vec4(color.rgb, alpha);
+                    }
+                }
+            }
+        "
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Vertex {
+    pos: [f32; 2],
+    primitive_index: u32,
+}
+vulkano::impl_vertex!(Vertex, pos, primitive_index);
+
+#[derive(Debug, Clone, AsStd430)]
+pub struct PrimitiveData {
+    ty: u32,
+    z_index: f32,
+    base_or_center: crevice::std430::Vec2,
+    color: crevice::std430::Vec4,
+    tex_base_or_half_size: crevice::std430::Vec2,
+    tex_scale_or_border_radius_and_stroke_width: crevice::std430::Vec2,
+    clip_min: crevice::std430::Vec2,
+    clip_max: crevice::std430::Vec2,
+}
+
+pub struct RenderData {
+    pub(crate) vertices: Vec<Vertex>,
+    pub(crate) indices: Vec<u32>,
+    primitive_data: Vec<<PrimitiveData as AsStd430>::Std430Type>,
+}
+
+impl RenderData {
+    fn new() -> Self { Self { vertices: vec![], indices: vec![], primitive_data: vec![] } }
+
+    pub fn add_rounded_rect(
+        &mut self,
+        color: [f32; 4],
+        z_index: f32,
+        rect: Rect,
+        clip: Rect,
+        border_radius: f32,
+        stroke_width: f32,
+        inverted: bool,
+    ) {
+        let primitive_index = self.primitive_data.len() as u32;
+        self.primitive_data.push(
+            PrimitiveData {
+                ty: if inverted { 3 } else { 2 },
+                color: crevice::std430::Vec4 { x: color[0], y: color[1], z: color[2], w: color[3] },
+                z_index,
+                base_or_center: rect.center().into(),
+                tex_base_or_half_size: (rect.size / 2.0).into(),
+                tex_scale_or_border_radius_and_stroke_width: crevice::std430::Vec2 {
+                    x: border_radius,
+                    y: stroke_width,
+                },
+                clip_min: clip.near_corner().into(),
+                clip_max: clip.far_corner().into(),
+            }
+            .as_std430(),
+        );
+        let vertex_id = self.vertices.len() as u32;
+        self.vertices.push(Vertex { pos: rect.near_corner().into(), primitive_index });
+        self.vertices.push(Vertex { pos: [rect.pos.x, rect.pos.y + rect.size.y], primitive_index });
+        self.vertices.push(Vertex { pos: [rect.pos.x + rect.size.x, rect.pos.y], primitive_index });
+        self.vertices.push(Vertex { pos: rect.far_corner().into(), primitive_index });
+        self.indices.push(vertex_id + 1);
+        self.indices.push(vertex_id);
+        self.indices.push(vertex_id + 2);
+
+        self.indices.push(vertex_id + 1);
+        self.indices.push(vertex_id + 3);
+        self.indices.push(vertex_id + 2);
+    }
+
+    pub fn add_text_quad(
+        &mut self,
+        color: [f32; 4],
+        z_index: f32,
+        rect: Rect,
+        tex_base: Vec2,
+        tex_scale: Vec2,
+    ) {
+        let primitive_index = self.primitive_data.len() as u32;
+        self.primitive_data.push(
+            PrimitiveData {
+                ty: 1,
+                color: crevice::std430::Vec4 { x: color[0], y: color[1], z: color[2], w: color[3] },
+                z_index,
+                base_or_center: rect.near_corner().into(),
+                tex_base_or_half_size: tex_base.into(),
+                tex_scale_or_border_radius_and_stroke_width: tex_scale.into(),
+                clip_min: rect.near_corner().into(),
+                clip_max: rect.far_corner().into(),
+            }
+            .as_std430(),
+        );
+        let vertex_id = self.vertices.len() as u32;
+        self.vertices.push(Vertex { pos: rect.near_corner().into(), primitive_index });
+        self.vertices.push(Vertex { pos: [rect.pos.x, rect.pos.y + rect.size.y], primitive_index });
+        self.vertices.push(Vertex { pos: [rect.pos.x + rect.size.x, rect.pos.y], primitive_index });
+        self.vertices.push(Vertex { pos: rect.far_corner().into(), primitive_index });
+        self.indices.push(vertex_id + 1);
+        self.indices.push(vertex_id);
+        self.indices.push(vertex_id + 2);
+
+        self.indices.push(vertex_id + 1);
+        self.indices.push(vertex_id + 3);
+        self.indices.push(vertex_id + 2);
+    }
+
+    pub fn add_lyon_data(
+        &mut self,
+        color: [f32; 4],
+        z_index: f32,
+        clip_min: [f32; 2],
+        clip_max: [f32; 2],
+    ) -> u32 {
+        let idx = self.primitive_data.len() as u32;
+        self.primitive_data.push(
+            PrimitiveData {
+                ty: 0,
+                color: crevice::std430::Vec4 { x: color[0], y: color[1], z: color[2], w: color[3] },
+                z_index,
+                base_or_center: Vec2::zero().into(),
+                tex_base_or_half_size: Vec2::zero().into(),
+                tex_scale_or_border_radius_and_stroke_width: Vec2::zero().into(),
+                clip_min: crevice::std430::Vec2 { x: clip_min[0], y: clip_min[1] },
+                clip_max: crevice::std430::Vec2 { x: clip_max[0], y: clip_max[1] },
+            }
+            .as_std430(),
+        );
+        idx
+    }
+
+    pub fn add_lyon_vertex(&mut self, primitive_index: u32, pos: [f32; 2]) -> u32 {
+        let idx = self.vertices.len() as u32;
+        self.vertices.push(Vertex { pos, primitive_index });
+        idx
+    }
+}
+
+pub struct Renderer {
+    queue: Arc<Queue>,
+    pipeline: std::sync::Arc<GraphicsPipeline<BuffersDefinition>>,
+    pub(crate) data: RenderData,
+    sampler: Arc<Sampler>,
+}
+impl Renderer {
+    pub fn new(render_pass: Arc<RenderPass>, device: Arc<Device>, queue: Arc<Queue>) -> Self {
+        let vs = vertex_shader::Shader::load(device.clone()).unwrap();
+        let fs = fragment_shader::Shader::load(device.clone()).unwrap();
+
+        let pipeline = Arc::new(
+            GraphicsPipeline::start()
+                .vertex_input(BuffersDefinition::new().vertex::<Vertex>())
+                .vertex_shader(vs.main_entry_point(), ())
+                .triangle_list()
+                .viewports_dynamic_scissors_irrelevant(1)
+                .fragment_shader(fs.main_entry_point(), ())
+                .blend_alpha_blending()
+                .depth_stencil(DepthStencil {
+                    depth_compare: Compare::LessOrEqual,
+                    ..DepthStencil::simple_depth_test()
+                })
+                .render_pass(Subpass::from(render_pass, 0).unwrap())
+                .build(device.clone())
+                .unwrap(),
+        );
+
+        let sampler = Sampler::new(
+            device,
+            Filter::Linear,
+            Filter::Linear,
+            MipmapMode::Nearest,
+            SamplerAddressMode::Repeat,
+            SamplerAddressMode::Repeat,
+            SamplerAddressMode::Repeat,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+        )
+        .unwrap();
+
+
+        Self { queue, pipeline, sampler, data: RenderData::new() }
+    }
+    pub fn render(&mut self, render_object: &PositionedRenderObject) {
+        if let PositionedRenderObject {
+            render_object:
+                RenderObject::RoundedRect {
+                    stroke_color,
+                    fill_color,
+                    stroke_width,
+                    border_radius,
+                    inverted,
+                },
+            clipping_rect,
+            rect,
+            z_index,
+        } = render_object
+        {
+            let border_radius_px = match border_radius {
+                Dimension::Paxel(px) => *px,
+                Dimension::Fraction(percent) => {
+                    (if rect.size.x > rect.size.y { rect.size.y } else { rect.size.x })
+                        * percent
+                        * 0.5
+                }
+            };
+            if let Some(stroke_color) = stroke_color {
+                self.data.add_rounded_rect(
+                    stroke_color.into_raw(),
+                    1.0 - *z_index as f32 / 65535.0,
+                    *rect,
+                    clipping_rect.unwrap_or(*rect),
+                    border_radius_px,
+                    *stroke_width,
+                    *inverted,
+                );
+            }
+            if let Some(fill_color) = fill_color {
+                let rect = rect.inset(*stroke_width);
+                self.data.add_rounded_rect(
+                    fill_color.into_raw(),
+                    1.0 - *z_index as f32 / 65535.0,
+                    rect,
+                    clipping_rect.unwrap_or(rect),
+                    (border_radius_px - *stroke_width).max(0.0),
+                    rect.size.maximum() / 2.0,
+                    *inverted,
+                );
+            }
+        }
+        if let PositionedRenderObject {
+            render_object: RenderObject::DebugRect,
+            clipping_rect,
+            rect,
+            ..
+        } = render_object
+        {
+            self.data.add_rounded_rect(
+                [1.0, 0.0, 0.0, 0.5],
+                0.0,
+                *rect,
+                clipping_rect.unwrap_or(*rect),
+                0.0,
+                2.0,
+                false,
+            );
+        }
+    }
+
+
+    pub fn finish(
+        &mut self,
+        font_texture: Arc<ImmutableImage>,
+        buffer_builder: &mut AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>,
+        dynamic_state: &DynamicState,
+        dimensions: &[u32; 2],
+    ) -> (impl GpuFuture, impl GpuFuture, impl GpuFuture) {
+        let push_constants =
+            vertex_shader::ty::PushConstantData { width: dimensions[0], height: dimensions[1] };
+
+        let layout = self.pipeline.layout().descriptor_set_layouts()[0].clone();
+
+        let texture = ImageView::new(font_texture).unwrap();
+
+        /*
+        dbg!(&self.data.primitive_data);
+        dbg!(&self.data.vertices);
+        dbg!(&self.data.indices);
+        */
+        let (primitive_buffer, primitive_fut) = ImmutableBuffer::from_iter(
+            self.data.primitive_data.drain(..),
+            BufferUsage::all(),
+            self.queue.clone(),
+        )
+        .unwrap();
+
+        let (vertex_buffer, vertex_fut) = ImmutableBuffer::from_iter(
+            self.data.vertices.drain(..),
+            BufferUsage::all(),
+            self.queue.clone(),
+        )
+        .unwrap();
+
+        let (index_buffer, index_fut) = ImmutableBuffer::from_iter(
+            self.data.indices.drain(..),
+            BufferUsage::all(),
+            self.queue.clone(),
+        )
+        .unwrap();
+
+        let descriptor_set = Arc::new(
+            PersistentDescriptorSet::start(layout)
+                .add_buffer(primitive_buffer)
+                .unwrap()
+                .add_sampled_image(texture, self.sampler.clone())
+                .unwrap()
+                .build()
+                .unwrap(),
+        );
+
+        buffer_builder
+            .draw_indexed(
+                self.pipeline.clone(),
+                dynamic_state,
+                vertex_buffer,
+                index_buffer,
+                descriptor_set,
+                push_constants,
+            )
+            .unwrap();
+
+        (primitive_fut, vertex_fut, index_fut)
+    }
+}

--- a/narui_core/src/vulkano_render/text_render.rs
+++ b/narui_core/src/vulkano_render/text_render.rs
@@ -1,5 +1,10 @@
-use super::vk_util::VulkanContext;
-use crate::{eval::layout::PositionedRenderObject, geom::Rect, RenderObject};
+use crate::{
+    eval::layout::PositionedRenderObject,
+    geom::Rect,
+    vulkano_render::renderer::RenderData,
+    RenderObject,
+    Vec2,
+};
 use glyph_brush::{
     ab_glyph::{FontArc, PxScale},
     BrushAction,
@@ -17,118 +22,16 @@ use std::{
     sync::Arc,
 };
 use vulkano::{
-    buffer::{BufferUsage, CpuAccessibleBuffer},
-    command_buffer::{AutoCommandBufferBuilder, DynamicState, PrimaryAutoCommandBuffer},
-    descriptor_set::persistent::{
-        PersistentDescriptorSet,
-        PersistentDescriptorSetImg,
-        PersistentDescriptorSetSampler,
-    },
-    device::{Device, Queue},
+    command_buffer::{CommandBufferExecFuture, PrimaryAutoCommandBuffer},
+    device::Queue,
     format::Format,
-    image::{view::ImageView, ImageDimensions, ImmutableImage, MipmapsCount},
-    pipeline::{
-        depth_stencil::{Compare, DepthStencil},
-        vertex::BuffersDefinition,
-        GraphicsPipeline,
-        GraphicsPipelineAbstract,
-    },
-    render_pass::{RenderPass, Subpass},
-    sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode},
+    image::{ImageDimensions, ImmutableImage, MipmapsCount},
+    sync::{GpuFuture, NowFuture},
 };
 
 lazy_static! {
     pub static ref FONT: FontArc = FontArc::try_from_slice(notosans::REGULAR_TTF).unwrap();
 }
-
-mod vertex_shader {
-    vulkano_shaders::shader! {
-        ty: "vertex",
-        src: "
-            #version 450
-            layout(push_constant) uniform PushConstantData {
-                uint width;
-                uint height;
-            } params;
-
-            layout(location = 0) in uint id;
-
-            layout(location = 1) in vec2 pos_min;
-            layout(location = 2) in vec2 pos_max;
-            layout(location = 3) in vec2 tex_min;
-            layout(location = 4) in vec2 tex_max;
-            layout(location = 5) in vec4 color;
-            layout(location = 6) in float z_index;
-
-            layout(location = 0) out vec2 tex_frag;
-            layout(location = 1) out vec4 color_frag;
-
-            void main() {
-                color_frag = color;
-
-                vec2 pos = vec2(0.0);
-                switch (id) {
-                    case 0:
-                        pos = pos_min;
-                        tex_frag = tex_min;
-                        break;
-                    case 1:
-                        pos = vec2(pos_max.x, pos_min.y);
-                        tex_frag = vec2(tex_max.x, tex_min.y);
-                        break;
-                    case 2:
-                        pos = vec2(pos_min.x, pos_max.y);
-                        tex_frag = vec2(tex_min.x, tex_max.y);
-                        break;
-                    case 3:
-                        pos = pos_max;
-                        tex_frag = tex_max;
-                        break;
-                }
-                gl_Position = vec4((pos / (vec2(params.width, params.height) / 2.) - vec2(1.)), z_index, 1.0);
-            }
-        "
-    }
-}
-mod fragment_shader {
-    vulkano_shaders::shader! {
-        ty: "fragment",
-        src: "
-            #version 450
-            layout(set = 0, binding = 0) uniform sampler2D tex;
-            layout(location = 0) in vec2 tex_frag;
-            layout(location = 1) in vec4 color_frag;
-
-            layout(location = 0) out vec4 f_color;
-
-            void main() {
-                float alpha = texture(tex, tex_frag).r;
-                if (alpha == 0.0) {
-                    discard;
-                }
-                f_color = color_frag;
-                f_color.a *= alpha;
-            }
-        "
-    }
-}
-
-#[derive(Default, Debug, Clone)]
-struct Vertex {
-    id: u32,
-}
-vulkano::impl_vertex!(Vertex, id);
-
-#[derive(Default, Debug, Clone)]
-struct InstanceData {
-    pos_min: [f32; 2],
-    pos_max: [f32; 2],
-    tex_min: [f32; 2],
-    tex_max: [f32; 2],
-    color: [f32; 4],
-    z_index: f32,
-}
-vulkano::impl_vertex!(InstanceData, pos_min, pos_max, tex_min, tex_max, color, z_index);
 
 #[derive(Debug, Copy, Clone)]
 struct Extra {
@@ -159,113 +62,36 @@ impl PartialEq for Extra {
 }
 
 pub struct TextRenderer {
-    device: Arc<Device>,
     queue: Arc<Queue>,
-    pipeline: std::sync::Arc<GraphicsPipeline<BuffersDefinition>>,
-    glyph_brush: GlyphBrush<InstanceData, Extra>,
-    quad_vertex_buffer: Arc<CpuAccessibleBuffer<[Vertex]>>,
-    instance_data_buffer: Arc<CpuAccessibleBuffer<[InstanceData]>>,
-    sampler: Arc<Sampler>,
-    descriptor_set: Arc<
-        PersistentDescriptorSet<(
-            ((), PersistentDescriptorSetImg<Arc<ImageView<Arc<ImmutableImage>>>>),
-            PersistentDescriptorSetSampler,
-        )>,
-    >,
+    glyph_brush: GlyphBrush<([f32; 4], f32, Rect, Vec2, Vec2), Extra>,
+    old_data: Vec<([f32; 4], f32, Rect, Vec2, Vec2)>,
     texture_bytes: Vec<u8>,
+    texture: Arc<ImmutableImage>,
+    texture_fut: Option<CommandBufferExecFuture<NowFuture, PrimaryAutoCommandBuffer>>,
 }
 impl TextRenderer {
-    pub fn new(render_pass: Arc<RenderPass>, queue: Arc<Queue>) -> Self {
-        let device = VulkanContext::get().device;
-
-        let vs = vertex_shader::Shader::load(device.clone()).unwrap();
-        let fs = fragment_shader::Shader::load(device.clone()).unwrap();
-
-        let pipeline = Arc::new(
-            GraphicsPipeline::start()
-                .vertex_input(
-                    BuffersDefinition::new().vertex::<Vertex>().instance::<InstanceData>(),
-                )
-                .vertex_shader(vs.main_entry_point(), ())
-                .triangle_strip()
-                .viewports_dynamic_scissors_irrelevant(1)
-                .fragment_shader(fs.main_entry_point(), ())
-                .blend_alpha_blending()
-                .depth_stencil(DepthStencil {
-                    depth_compare: Compare::LessOrEqual,
-                    ..DepthStencil::simple_depth_test()
-                })
-                .render_pass(Subpass::from(render_pass, 0).unwrap())
-                .build(device.clone())
-                .unwrap(),
-        );
-
+    pub fn new(queue: Arc<Queue>) -> Self {
         let glyph_brush = GlyphBrushBuilder::using_font(FONT.clone()).build();
 
-        let quad_vertex_buffer = CpuAccessibleBuffer::from_iter(
-            device.clone(),
-            BufferUsage::all(),
-            false,
-            [Vertex { id: 0 }, Vertex { id: 1 }, Vertex { id: 2 }, Vertex { id: 3 }]
-                .iter()
-                .cloned(),
-        )
-        .unwrap();
+        let (w, h) = glyph_brush.texture_dimensions();
+        let texture_bytes = vec![0u8; (w * h) as usize];
 
-        let instance_data_buffer = CpuAccessibleBuffer::<[InstanceData]>::from_iter(
-            device.clone(),
-            BufferUsage::all(),
-            false,
-            (vec![]).into_iter(),
-        )
-        .unwrap();
-
-        let (image, _) = ImmutableImage::from_iter(
-            vec![0u8].into_iter(),
+        let (texture, texture_fut) = ImmutableImage::from_iter(
+            [0u8].iter().cloned(),
             ImageDimensions::Dim2d { width: 1, height: 1, array_layers: 1 },
             MipmapsCount::One,
             Format::R8Unorm,
             queue.clone(),
         )
         .unwrap();
-        let texture = ImageView::new(image).unwrap();
-
-        let sampler = Sampler::new(
-            device.clone(),
-            Filter::Linear,
-            Filter::Linear,
-            MipmapMode::Nearest,
-            SamplerAddressMode::Repeat,
-            SamplerAddressMode::Repeat,
-            SamplerAddressMode::Repeat,
-            0.0,
-            1.0,
-            0.0,
-            0.0,
-        )
-        .unwrap();
-
-        let layout = pipeline.layout().descriptor_set_layouts()[0].clone();
-        let descriptor_set = Arc::new(
-            PersistentDescriptorSet::start(layout)
-                .add_sampled_image(texture, sampler.clone())
-                .unwrap()
-                .build()
-                .unwrap(),
-        );
-        let (w, h) = glyph_brush.texture_dimensions();
-        let texture_bytes = vec![0u8; (w * h) as usize];
 
         Self {
-            device,
             queue,
-            pipeline,
             glyph_brush,
-            quad_vertex_buffer,
-            instance_data_buffer,
-            sampler,
-            descriptor_set,
+            old_data: vec![],
             texture_bytes,
+            texture,
+            texture_fut: Some(texture_fut),
         }
     }
     pub fn render<'a>(&mut self, render_object: &PositionedRenderObject<'a>) {
@@ -293,12 +119,11 @@ impl TextRenderer {
             );
         }
     }
+
     pub fn finish(
         &mut self,
-        buffer_builder: &mut AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>,
-        dynamic_state: &DynamicState,
-        dimensions: &[u32; 2],
-    ) {
+        data: &mut RenderData,
+    ) -> (Arc<ImmutableImage>, Option<impl GpuFuture>) {
         let (width, height) = self.glyph_brush.texture_dimensions();
         let texture_bytes = &mut self.texture_bytes;
         let mut texture_upload = false;
@@ -329,36 +154,26 @@ impl TextRenderer {
                 let clipped_tex_size = (clipped.size / original_rect.size) * original_tex_rect.size;
                 let clipped_tex_rect = Rect { pos: original_tex_rect.pos, size: clipped_tex_size };
 
-                InstanceData {
-                    pos_min: clipped.near_corner().into(),
-                    pos_max: clipped.far_corner().into(),
-                    tex_min: clipped_tex_rect.near_corner().into(),
-                    tex_max: clipped_tex_rect.far_corner().into(),
-                    color: vertex_data.extra.color,
-                    z_index: vertex_data.extra.z,
-                }
+                (
+                    vertex_data.extra.color,
+                    vertex_data.extra.z,
+                    clipped,
+                    clipped_tex_rect.near_corner(),
+                    clipped_tex_rect.size / clipped.size,
+                )
             },
         ) {
-            Ok(BrushAction::Draw(instances)) => {
-                /* //draw texture:
-                vertices.push(InstanceData {
-                    pos_min: [100., 100.],
-                    pos_max: [500., 500.],
-                    tex_min: [0., 0.],
-                    tex_max: [1., 1.],
-                    color: [1., 1., 1., 1.]
-                });
-                 */
-
-                self.instance_data_buffer = CpuAccessibleBuffer::<[InstanceData]>::from_iter(
-                    self.device.clone(),
-                    BufferUsage::all(),
-                    false,
-                    instances.into_iter(),
-                )
-                .unwrap();
+            Ok(BrushAction::Draw(quads)) => {
+                for (color, z, rect, tex_base, tex_scale) in &quads {
+                    data.add_text_quad(*color, *z, *rect, *tex_base, *tex_scale)
+                }
+                self.old_data = quads;
             }
-            Ok(BrushAction::ReDraw) => {}
+            Ok(BrushAction::ReDraw) => {
+                for (color, z, rect, tex_base, tex_scale) in &self.old_data {
+                    data.add_text_quad(*color, *z, *rect, *tex_base, *tex_scale)
+                }
+            }
             Err(BrushError::TextureTooSmall { suggested: (w, h) }) => {
                 self.texture_bytes = vec![0u8; (w * h) as usize];
                 self.glyph_brush.resize_texture(w, h);
@@ -366,7 +181,7 @@ impl TextRenderer {
         }
 
         if texture_upload {
-            let (image, _) = ImmutableImage::from_iter(
+            let (texture, texture_fut) = ImmutableImage::from_iter(
                 self.texture_bytes.iter().cloned(),
                 ImageDimensions::Dim2d { width, height, array_layers: 1 },
                 MipmapsCount::One,
@@ -374,28 +189,10 @@ impl TextRenderer {
                 self.queue.clone(),
             )
             .unwrap();
-            let texture = ImageView::new(image).unwrap();
-
-            let layout = self.pipeline.layout().descriptor_set_layouts()[0].clone();
-            self.descriptor_set = Arc::new(
-                PersistentDescriptorSet::start(layout)
-                    .add_sampled_image(texture, self.sampler.clone())
-                    .unwrap()
-                    .build()
-                    .unwrap(),
-            );
+            self.texture = texture;
+            self.texture_fut = Some(texture_fut);
         }
 
-        let push_constants =
-            vertex_shader::ty::PushConstantData { width: dimensions[0], height: dimensions[1] };
-        buffer_builder
-            .draw(
-                self.pipeline.clone(),
-                dynamic_state,
-                (self.quad_vertex_buffer.clone(), self.instance_data_buffer.clone()),
-                self.descriptor_set.clone(),
-                push_constants,
-            )
-            .unwrap();
+        (self.texture.clone(), self.texture_fut.take())
     }
 }

--- a/narui_core/src/vulkano_render/vk_util.rs
+++ b/narui_core/src/vulkano_render/vk_util.rs
@@ -3,7 +3,7 @@ use lazy_static::lazy_static;
 use std::sync::Arc;
 use vulkano::{
     device::{physical::PhysicalDevice, Device, DeviceExtensions, Queue},
-    instance::Instance,
+    instance::{Instance, InstanceExtensions},
     Version,
 };
 
@@ -16,10 +16,19 @@ pub struct VulkanContext {
 lazy_static! {
     pub static ref VULKAN_CONTEXT: VulkanContext = VulkanContext::create().unwrap();
 }
+
+
 impl VulkanContext {
     pub fn create() -> Result<Self> {
         let required_extensions = vulkano_win::required_extensions();
-        let instance = Instance::new(None, Version::V1_2, &required_extensions, None)?;
+        let extensions = InstanceExtensions {
+            ext_debug_utils: true,
+            ext_debug_report: true,
+            ..required_extensions
+        };
+        dbg!(required_extensions);
+        let instance = Instance::new(None, Version::V1_2, &extensions, None)?;
+
         let physical = PhysicalDevice::enumerate(&instance)
             .next()
             .ok_or_else(|| anyhow!("No physical device found"))?;
@@ -29,6 +38,7 @@ impl VulkanContext {
             khr_swapchain: true,
             khr_storage_buffer_storage_class: true,
             khr_8bit_storage: true,
+            khr_shader_non_semantic_info: true,
             ..(*physical.required_extensions())
         };
         let (device, queues) =

--- a/narui_macros/src/widget_macro.rs
+++ b/narui_macros/src/widget_macro.rs
@@ -115,13 +115,13 @@ pub fn widget(
     let mut constrain_fns = vec![];
     let mut constrain_fn_uses = vec![];
     let mut arg_names = get_arg_names(&function);
-    arg_names.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+    arg_names.sort_by_key(|a| a.to_string());
     arg_names = arg_names.into_iter().filter(|ident| &ident.to_string() != "context").collect();
 
     let mut match_arms = Vec::new();
     let first_arg = arg_names.get(0);
     for (this_arg, next_arg) in
-        arg_names.iter().zip(arg_names.iter().skip(1).map(|x| Some(x)).chain(Some(None)))
+        arg_names.iter().zip(arg_names.iter().skip(1).map(Some).chain(Some(None)))
     {
         let constrain_fn_ident = Ident::new(
             &format!("__{}_{}_constrain_arg", function_ident, this_arg),

--- a/narui_widgets/src/rect.rs
+++ b/narui_widgets/src/rect.rs
@@ -1,22 +1,6 @@
 use crate::layout::{positioned, sized, stack};
-use narui::{
-    layout::Maximal,
-    re_export::lyon::{
-        algorithms::{
-            math::{point, rect as lyon_rect},
-            path::{
-                builder::{BorderRadii, PathBuilder},
-                Winding,
-            },
-        },
-        lyon_algorithms::path::path::Builder,
-        lyon_tessellation::{FillTessellator, StrokeOptions, StrokeTessellator},
-    },
-    renderer::ColoredBuffersBuilder,
-    *,
-};
+use narui::{layout::Maximal, *};
 use narui_macros::{rsx, widget};
-use std::sync::Arc;
 
 
 #[widget(border_radius = Dimension::default(), fill = None, stroke = None)]
@@ -26,61 +10,14 @@ pub fn rect_leaf(
     stroke: Option<(Color, f32)>,
     context: &mut WidgetContext,
 ) -> FragmentInner {
-    let path_gen = Arc::new(
-        move |size: Vec2,
-              fill_tess: &mut FillTessellator,
-              stroke_tess: &mut StrokeTessellator,
-              mut buffers_builder: ColoredBuffersBuilder| {
-            let border_radius_px = match border_radius {
-                Paxel(px) => px,
-                Fraction(percent) => (if size.x > size.y { size.y } else { size.x }) * percent,
-            };
-            let border_radii = BorderRadii {
-                top_left: border_radius_px,
-                top_right: border_radius_px,
-                bottom_left: border_radius_px,
-                bottom_right: border_radius_px,
-            };
-            if let Some(fill) = fill {
-                let mut builder = Builder::new();
-                builder.add_rounded_rectangle(
-                    &lyon_rect(0.0, 0.0, size.x, size.y),
-                    &border_radii,
-                    Winding::Positive,
-                );
-                fill_tess
-                    .tessellate_path(
-                        &builder.build(),
-                        &Default::default(),
-                        &mut buffers_builder.with_color(fill),
-                    )
-                    .unwrap();
-            }
-            if let Some((stroke, border_width)) = stroke {
-                let mut builder = Builder::new();
-                builder.add_rounded_rectangle(
-                    &lyon_rect(
-                        border_width / 2.0,
-                        border_width / 2.0,
-                        size.x - border_width,
-                        size.y - border_width,
-                    ),
-                    &border_radii,
-                    Winding::Positive,
-                );
-                stroke_tess
-                    .tessellate_path(
-                        &builder.build(),
-                        &StrokeOptions::default().with_line_width(border_width),
-                        &mut buffers_builder.with_color(stroke),
-                    )
-                    .unwrap();
-            }
-        },
-    );
-
     FragmentInner::Leaf {
-        render_object: RenderObject::Path { path_gen },
+        render_object: RenderObject::RoundedRect {
+            stroke_color: stroke.map(|v| v.0),
+            fill_color: fill,
+            stroke_width: stroke.map(|v| v.1).unwrap_or(0.0),
+            border_radius,
+            inverted: false,
+        },
         layout: Box::new(Maximal),
     }
 }
@@ -92,55 +29,14 @@ pub fn inverse_rect_leaf(
     fill: Option<Color>,
     context: &mut WidgetContext,
 ) -> FragmentInner {
-    let path_gen = Arc::new(
-        move |size: Vec2,
-              fill_tess: &mut FillTessellator,
-              _stroke_tess: &mut StrokeTessellator,
-              mut buffers_builder: ColoredBuffersBuilder| {
-            let br = match border_radius {
-                Paxel(px) => px,
-                Fraction(percent) => (if size.x > size.y { size.y } else { size.x }) * percent,
-            };
-            if let Some(fill) = fill {
-                let mut builder = Builder::new();
-                let m = 0.5522848;
-                let mut corner = |a: Vec2, b: Vec2, c: Vec2| {
-                    builder.begin(a.into());
-                    builder.line_to(point(b.x, b.y));
-                    builder.cubic_bezier_to(
-                        point(b.x, (a.y - b.y) * m + b.y),
-                        point((a.x - c.x) * m + c.x, c.y),
-                        point(c.x, c.y),
-                    );
-                    builder.line_to(a.into());
-                    builder.end(true);
-                };
-                corner(Vec2::zero(), Vec2::new(0., br / 2.), Vec2::new(br / 2., 0.));
-                corner(
-                    Vec2::new(0.0, size.y),
-                    Vec2::new(0.0, size.y - br / 2.),
-                    Vec2::new(br / 2., size.y),
-                );
-                corner(
-                    Vec2::new(size.x, 0.0),
-                    Vec2::new(size.x, br / 2.),
-                    Vec2::new(size.x - br / 2., 0.0),
-                );
-                corner(size, size.with_y(size.y - br / 2.), size.with_x(size.x - br / 2.));
-
-                fill_tess
-                    .tessellate_path(
-                        &builder.build(),
-                        &Default::default(),
-                        &mut buffers_builder.with_color(fill),
-                    )
-                    .unwrap();
-            }
-        },
-    );
-
     FragmentInner::Leaf {
-        render_object: RenderObject::Path { path_gen },
+        render_object: RenderObject::RoundedRect {
+            inverted: true,
+            stroke_color: None,
+            fill_color: fill,
+            stroke_width: 0.0,
+            border_radius,
+        },
         layout: Box::new(Maximal),
     }
 }


### PR DESCRIPTION
This renders lyon and text in a single pass, as well as
adding special handling for (inverted) (stroked) rounded rects.

Brings circle_bench from ~55fps to ~85-90fps

## TODO:
- [ ] maybe properly sorting the text with the rest of the lyon / rounded rect elements
- [ ] maybe split the draw calls at z indices where a `RawRenderer` exists