### PR TITLE
Subpass rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dhat*
 vk_layer_settings.txt
 cargo-timing*
 narui_core/src/vulkano_render/blur.rs
+*.cap
+blur.sh
+.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,12 +20,6 @@ checksum = "d9fe5e32de01730eb1f6b7f5b51c17e03e2325bf40a74f754f04f130043affff"
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
-name = "ahash"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
@@ -59,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "approx"
@@ -80,9 +74,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ash"
-version = "0.33.2+1.2.186"
+version = "0.33.3+1.2.191"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2b957a47afef62973ed5fa0a52afb3289c7a243bfbc3906090b8434971237"
+checksum = "cc4f1d82f164f838ae413296d1131aa6fa79b917d25bebaa7033d25620c09219"
 dependencies = [
  "libloading 0.7.0",
 ]
@@ -613,31 +607,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
-name = "halfbrown"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c12499524b5585419ab2f51545a19b842263a373580a83c0eb98a0142a260a10"
-dependencies = [
- "hashbrown 0.7.2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-dependencies = [
- "ahash 0.3.8",
- "autocfg",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash 0.7.4",
+ "ahash",
 ]
 
 [[package]]
@@ -677,14 +652,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -697,6 +672,12 @@ checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "jni-sys"
@@ -712,9 +693,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
 
 [[package]]
 name = "libloading"
@@ -772,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_algorithms"
-version = "0.17.5"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1ebc5107076627bc9e402b09d11ba8ca68e06e3053b923bce9570ef70bf960"
+checksum = "3455481f62077255e4837ba768d662e17ba80ef9fbf07bc038a5d9796d903f57"
 dependencies = [
  "lyon_path",
  "sid",
@@ -793,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "lyon_path"
-version = "0.17.6"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef7433accd4515fc98f59bb3cdf565a9615f0c666f50bfcb96134bbd91ccc04"
+checksum = "5b0a59fdf767ca0d887aa61d1b48d4bbf6a124c1a45503593f7d38ab945bfbc0"
 dependencies = [
  "lyon_geom",
 ]
@@ -820,12 +801,6 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -868,15 +843,15 @@ dependencies = [
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6595bb28ed34f43c3fe088e48f6cfb2e033cab45f25a5384d5fdf564fbc8c4b2"
+checksum = "0c835948974f68e0bd58636fc6c5b1fbff7b297e3046f11b3b3c18bbac012c6d"
 
 [[package]]
 name = "mint"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519df8d6856dcd4b40519947737b408f81be051fc032590659cae5d77d664185"
+checksum = "793e84ff3f9a63214a5475097fac2a3e3674f862efcaeabebf5f4da36d7512ec"
 
 [[package]]
 name = "mio"
@@ -929,7 +904,7 @@ dependencies = [
 name = "narui_core"
 version = "0.1.0"
 dependencies = [
- "ahash 0.7.4",
+ "ahash",
  "anyhow",
  "crevice",
  "ctor",
@@ -937,8 +912,7 @@ dependencies = [
  "derivative",
  "freelist",
  "glyph_brush",
- "halfbrown",
- "hashbrown 0.11.2",
+ "hashbrown",
  "lazy_static",
  "log",
  "lyon",
@@ -961,7 +935,7 @@ name = "narui_macros"
 version = "0.1.0"
 dependencies = [
  "bind_match",
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -976,6 +950,8 @@ version = "0.1.0"
 dependencies = [
  "narui_core",
  "narui_macros",
+ "vulkano",
+ "vulkano-shaders",
 ]
 
 [[package]]
@@ -1108,7 +1084,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486ea01961c4a818096de679a8b740b26d9033146ac5291b1c98557658f8cdd9"
 dependencies = [
- "proc-macro-crate 1.0.0",
+ "proc-macro-crate 1.1.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1141,9 +1117,9 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "ordered-float"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
+checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
 dependencies = [
  "num-traits",
 ]
@@ -1267,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
 
 [[package]]
 name = "ppv-lite86"
@@ -1288,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
@@ -1466,8 +1442,14 @@ version = "0.1.0"
 dependencies = [
  "derivative",
  "freelist",
- "hashbrown 0.11.2",
+ "log",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "same-file"
@@ -1495,6 +1477,31 @@ name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "shaderc"
@@ -1537,15 +1544,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -1567,16 +1574,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv_headers"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5b132530b1ac069df335577e3581765995cba5a13995cdbbdbc8fb057c532c"
-dependencies = [
- "bitflags",
- "num-traits",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,9 +1587,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1627,18 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1716,8 +1713,7 @@ dependencies = [
 [[package]]
 name = "vulkano"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e631daf0d54bf36908ccff9f38ced7ff253a327e396ac13503a11401bee8c38"
+source = "git+https://github.com/vulkano-rs/vulkano#9122da1356908566f3bc146ad31d1544b04f8bd4"
 dependencies = [
  "ash",
  "crossbeam-queue",
@@ -1727,7 +1723,11 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "parking_lot",
+ "proc-macro2",
+ "quote",
  "regex",
+ "serde",
+ "serde_json",
  "shared_library",
  "smallvec",
  "vk-parse",
@@ -1736,22 +1736,19 @@ dependencies = [
 [[package]]
 name = "vulkano-shaders"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f45834e124ae0fdc95a358d83f163d9b14e9ec7780d99cd5aecbf4e76b1a67e"
+source = "git+https://github.com/vulkano-rs/vulkano#9122da1356908566f3bc146ad31d1544b04f8bd4"
 dependencies = [
- "num-traits",
  "proc-macro2",
  "quote",
  "shaderc",
- "spirv_headers",
  "syn",
+ "vulkano",
 ]
 
 [[package]]
 name = "vulkano-win"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5a84fe7d636a1aefdaecabb89b8c47d0b3a785653a38ffbc69a34fb46f6784"
+source = "git+https://github.com/vulkano-rs/vulkano#9122da1356908566f3bc146ad31d1544b04f8bd4"
 dependencies = [
  "cocoa 0.20.2",
  "metal",
@@ -1916,13 +1913,12 @@ dependencies = [
 
 [[package]]
 name = "x11-dl"
-version = "2.18.5"
+version = "2.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
+checksum = "ea26926b4ce81a6f5d9d0f3a0bc401e5a37c6ae14a1bfaa8ff6099ca80038c59"
 dependencies = [
  "lazy_static",
  "libc",
- "maybe-uninit",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ debug_bounds = ["narui_core/debug_bounds"]
 
 [profile.release]
 lto = "fat"
-# debug = true
+debug = true

--- a/examples/blur.rs
+++ b/examples/blur.rs
@@ -1,0 +1,61 @@
+use narui::*;
+
+#[widget]
+pub fn draggable_rect(initial_pos: Vec2, context: &mut WidgetContext) -> Fragment {
+    let clicked = context.listenable(false);
+    let drag_start_pos = context.listenable(Vec2::zero());
+    let pos = context.listenable(initial_pos);
+    let offset = context.listenable(Vec2::zero());
+    let abs_pos = context.listen(pos) + context.listen(offset);
+
+    rsx! {
+        <positioned pos=AbsolutePosition::from_offset(abs_pos.into())>
+            <input on_move = move |context, _, abs_pos| {
+                if context.spy(clicked) {
+                    context.shout(offset, abs_pos - context.spy(drag_start_pos));
+                }
+            }
+            on_click = move |context, is_clicked, _, abs_pos| {
+                context.shout(clicked, is_clicked);
+                context.shout(drag_start_pos, abs_pos);
+                if !is_clicked {
+                    context.shout(pos, context.spy(offset) + context.spy(pos));
+                    context.shout(offset, Vec2::zero());
+                }
+            }>
+                <rect stroke=Some((Color::new(0.0, 1.0, 0., 1.0), 10.0)) constraint=BoxConstraints::tight(200.0, 200.0) />
+            </input>
+        </positioned>
+    }
+}
+
+#[widget]
+pub fn top(context: &mut WidgetContext) -> Fragment {
+    rsx! {
+        <blur sigma=1.>
+            <stack>
+                <backdrop_blur sigma=10.>
+                    <stack>
+                        <positioned><rect fill=Some(Color::new(1.0, 0.0, 0.0, 1.0))/></positioned>
+                        <text size=200.>{"test text"}</text>
+                    </stack>
+                </backdrop_blur>
+                <draggable_rect initial_pos=Vec2::zero() />
+                <draggable_rect initial_pos=Vec2::new(100.0, 0.0) />
+                <draggable_rect initial_pos=Vec2::new(200.0, 0.0) />
+                <draggable_rect initial_pos=Vec2::new(300.0, 0.0) />
+                <draggable_rect initial_pos=Vec2::new(400.0, 0.0) />
+            </stack>
+        </blur>
+    }
+}
+
+fn main() {
+    env_logger::init();
+    app::render(
+        app::WindowBuilder::new().with_title("narui blur demo"),
+        rsx_toplevel! {
+            <top />
+        },
+    );
+}

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -31,6 +31,7 @@ pub fn reveal_box(
         children,
         layout: Box::new(RevealClipLayout { reveal }),
         is_clipper: true,
+        subpass: None,
     }
 }
 
@@ -44,11 +45,13 @@ pub fn top(context: &mut WidgetContext) -> Fragment {
                     <flexible>
                         <padding padding=EdgeInsets::all(10.)>
                             <reveal_box reveal=context.listen(slider_value)>
-                                <rect fill=Some(Color::new(0., 0.7, 0.7, 1.0)) border_radius=Fraction(1.) do_clipping=true>
-                                    <text size=100.>
-                                        {"some really long text, that gets clipped..."}
-                                    </text>
-                                </rect>
+                                <align alignment=Alignment::center()>
+                                    <rect fill=Some(Color::new(0., 0.7, 0.7, 1.0)) border_radius=Fraction(1.) do_clipping=true>
+                                        <text size=100.>
+                                            {"some really long text, that gets clipped..."}
+                                        </text>
+                                    </rect>
+                                </align>
                             </reveal_box>
                         </padding>
                     </flexible>

--- a/examples/minimal_delta.rs
+++ b/examples/minimal_delta.rs
@@ -9,7 +9,7 @@ pub fn btn(context: &mut WidgetContext) -> Fragment {
         Color::new(0., 1., 0., 1.)
     };
 
-    let callback = move |context: &CallbackContext, is_clicked| {
+    let callback = move |context: &CallbackContext, is_clicked, _, _| {
         context.shout(clicked, is_clicked);
     };
 

--- a/examples/node_graph.rs
+++ b/examples/node_graph.rs
@@ -26,7 +26,7 @@ pub fn drag_detector(
     let click_started = context.listenable(false);
     let clicked = context.listenable(false);
     let key = context.widget_local.idx;
-    let on_click = move |context: &CallbackContext, clicked_current| {
+    let on_click = move |context: &CallbackContext, clicked_current, _, _| {
         context.shout(clicked, clicked_current);
         if clicked_current {
             context.shout(click_started, true);
@@ -35,7 +35,7 @@ pub fn drag_detector(
             on_end(context, key)
         }
     };
-    let on_move = move |context: &CallbackContext, position| {
+    let on_move = move |context: &CallbackContext, position, _| {
         if context.spy(click_started) {
             context.shout(click_start_position, position);
             context.shout(click_started, false);

--- a/examples/text_alpha_test.rs
+++ b/examples/text_alpha_test.rs
@@ -16,7 +16,7 @@ pub fn top(context: &mut WidgetContext) -> Fragment {
 fn main() {
     env_logger::init();
     app::render(
-        app::WindowBuilder::new().with_title("narui minimal demo"),
+        app::WindowBuilder::new().with_title("narui text alpha demo"),
         rsx_toplevel! {
             <top />
         },

--- a/narui_core/Cargo.toml
+++ b/narui_core/Cargo.toml
@@ -19,9 +19,9 @@ lyon = "0.17.5"
 winit = "0.25.0"
 anyhow = "1.0.43"
 lazy_static = "1.4.0"
-vulkano = "0.25.0"
-vulkano-shaders = "0.25.0"
-vulkano-win = "0.25.0"
+vulkano = { git = "https://github.com/vulkano-rs/vulkano" }
+vulkano-shaders = { git = "https://github.com/vulkano-rs/vulkano" }
+vulkano-win = { git = "https://github.com/vulkano-rs/vulkano" }
 derivative = "2.2.0"
 glyph_brush = "0.7.2"
 notosans = "0.1.0"
@@ -37,4 +37,3 @@ smallvec = "1.6.1"
 take_mut = "0.2.2"
 tinyset = { version = "0.4.6", default-features = false }
 crevice = "0.7.1"
-halfbrown = "0.1.11"

--- a/narui_core/src/hooks/listenable.rs
+++ b/narui_core/src/hooks/listenable.rs
@@ -194,3 +194,23 @@ impl<'a, T: 'static> Deref for ListenableGuard<'a, T> {
         &*self.entry.downcast_ref().expect("ListenableGuard has wrong type")
     }
 }
+
+pub struct MappedListenableGuard<'a, T, MT, FN: Fn(&T) -> &MT> {
+    pub(crate) entry: PatchTreeEntry<'a>,
+    pub(crate) mapping_function: FN,
+    pub(crate) phantom: PhantomData<T>,
+    pub(crate) phantom2: PhantomData<MT>,
+}
+
+impl<'a, T: 'static, FN, MT> Deref for MappedListenableGuard<'a, T, MT, FN>
+where
+    FN: Fn(&T) -> &MT,
+{
+    type Target = MT;
+
+    fn deref(&self) -> &Self::Target {
+        (self.mapping_function)(
+            &*self.entry.downcast_ref().expect("ListenableGuard has wrong type"),
+        )
+    }
+}

--- a/narui_core/src/hooks/measure.rs
+++ b/narui_core/src/hooks/measure.rs
@@ -14,6 +14,7 @@ pub enum MeasureError {
 pub trait ContextMeasure {
     fn measure_size(&self, idx: Fragment) -> Result<Vec2, MeasureError>;
     fn measure_offset(&self, idx1: Fragment, idx2: Fragment) -> Result<Vec2, MeasureError>;
+    fn measure(&self, idx: Fragment) -> Result<Rect, MeasureError>;
 }
 impl ContextMeasure for CallbackContext<'_> {
     fn measure_size(&self, idx: Fragment) -> Result<Vec2, MeasureError> {
@@ -26,6 +27,8 @@ impl ContextMeasure for CallbackContext<'_> {
         let ro2 = get_layout(self, idx2)?;
         Ok(ro2.pos - ro1.pos)
     }
+
+    fn measure(&self, idx: Fragment) -> Result<Rect, MeasureError> { get_layout(self, idx) }
 }
 
 fn get_layout(context: &CallbackContext, idx: Fragment) -> Result<Rect, MeasureError> {

--- a/narui_core/src/hooks/thread.rs
+++ b/narui_core/src/hooks/thread.rs
@@ -50,7 +50,7 @@ impl<'a> ContextThread for WidgetContext<'a> {
         let thread_context = self.thread_context();
         let callback = Arc::new(callback);
         self.effect(
-            move || {
+            move |_| {
                 let thread_context = thread_context.clone();
                 let cloned_callback = callback.clone();
                 let (sender, receiver) = sync_channel(8);

--- a/narui_core/src/util/geom.rs
+++ b/narui_core/src/util/geom.rs
@@ -25,6 +25,7 @@ impl Vec2 {
     pub fn with_x(&self, x: f32) -> Self { Self { x, ..*self } }
     pub fn with_y(&self, y: f32) -> Self { Self { y, ..*self } }
     pub fn maximum(&self) -> f32 { self.x.max(self.y) }
+    pub fn pixels(&self) -> [u32; 2] { [self.x.round() as u32, self.y.round() as u32] }
 }
 impl Add for Vec2 {
     type Output = Vec2;
@@ -131,6 +132,7 @@ pub struct Rect {
     pub size: Vec2,
 }
 impl Rect {
+    pub fn zero() -> Self { Self { pos: Vec2::zero(), size: Vec2::zero() } }
     pub fn contains(self, point: Vec2) -> bool {
         point.x >= self.pos.x
             && point.y >= self.pos.y
@@ -143,6 +145,18 @@ impl Rect {
     }
     pub fn near_corner(&self) -> Vec2 { self.pos }
     pub fn far_corner(&self) -> Vec2 { self.pos + self.size }
+    pub fn top_left_corner(&self) -> Vec2 {
+        Vec2 {
+            x: self.pos.x.min(self.pos.x + self.size.x),
+            y: self.pos.y.min(self.pos.y + self.size.y),
+        }
+    }
+    pub fn bottom_right_corner(&self) -> Vec2 {
+        Vec2 {
+            x: self.pos.x.max(self.pos.x + self.size.x),
+            y: self.pos.y.max(self.pos.y + self.size.y),
+        }
+    }
     pub fn clip(&self, clipper: Rect) -> Rect {
         Rect::from_corners(
             Vec2::new(
@@ -159,4 +173,5 @@ impl Rect {
     pub fn inset(&self, val: f32) -> Self {
         Self { pos: self.pos + val, size: self.size - 2.0 * val }
     }
+    pub fn minus_position(&self, pos: Vec2) -> Self { Self { pos: self.pos - pos, ..*self } }
 }

--- a/narui_core/src/vulkano_render/input_handler.rs
+++ b/narui_core/src/vulkano_render/input_handler.rs
@@ -76,25 +76,35 @@ impl InputHandler {
                 if self.cursor_moved {
                     let is_hover = rect.contains(self.cursor_position);
                     if input_state.hover != is_hover {
-                        on_hover(&context, is_hover);
+                        on_hover(
+                            &context,
+                            is_hover,
+                            self.cursor_position - rect.pos,
+                            self.cursor_position,
+                        );
                         input_state.hover = is_hover;
                         updated = true;
                     }
                     if input_state.clicked || is_hover {
-                        on_move(&context, self.cursor_position - rect.pos);
+                        on_move(&context, self.cursor_position - rect.pos, self.cursor_position);
                         updated = true;
                     }
                 }
                 if self.cursor_pressed && rect.contains(self.cursor_position) {
                     input_state.clicked = true;
-                    on_click(&context, true);
+                    on_click(&context, true, self.cursor_position - rect.pos, self.cursor_position);
                     updated = true;
                 }
                 if self.cursor_released
                     && (input_state.clicked || rect.contains(self.cursor_position))
                 {
                     input_state.clicked = false;
-                    on_click(&context, false);
+                    on_click(
+                        &context,
+                        false,
+                        self.cursor_position - rect.pos,
+                        self.cursor_position,
+                    );
                     updated = true;
                 }
             }

--- a/narui_core/src/vulkano_render/lyon.rs
+++ b/narui_core/src/vulkano_render/lyon.rs
@@ -1,5 +1,5 @@
 use crate::{
-    eval::layout::PositionedRenderObject,
+    eval::layout::{PositionedElement, RenderObjectOrSubPass},
     geom::Vec2,
     re_export::lyon::lyon_tessellation::{Count, GeometryBuilderError, VertexId},
     vulkano_render::primitive_renderer::RenderData,
@@ -129,18 +129,16 @@ impl Lyon {
             stroke_tessellator: StrokeTessellator::new(),
         }
     }
-    pub fn render<'a>(
-        &mut self,
-        data: &mut RenderData,
-        render_object: &PositionedRenderObject<'a>,
-    ) {
+    pub fn render<'a>(&mut self, data: &mut RenderData, render_object: &PositionedElement<'a>) {
         let clipping_rect = if let Some(clipping_rect) = render_object.clipping_rect {
             render_object.rect.clip(clipping_rect)
         } else {
             render_object.rect
         };
 
-        if let RenderObject::Path { path_gen } = render_object.render_object {
+        if let RenderObjectOrSubPass::RenderObject(RenderObject::Path { path_gen }) =
+            render_object.element
+        {
             (path_gen)(
                 render_object.rect.size,
                 &mut self.fill_tessellator,

--- a/narui_core/src/vulkano_render/mod.rs
+++ b/narui_core/src/vulkano_render/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod lyon;
 pub(crate) mod primitive_renderer;
 pub mod raw_render;
 pub(crate) mod render;
+pub(crate) mod subpass_stack;
 pub(crate) mod vk_util;
 
 

--- a/narui_core/src/vulkano_render/raw_render.rs
+++ b/narui_core/src/vulkano_render/raw_render.rs
@@ -1,9 +1,11 @@
-use crate::{eval::layout::PositionedRenderObject, RenderObject};
+/*
+use crate::{eval::layout::PositionedElement, RenderObject};
 use std::sync::Arc;
 use vulkano::{
     command_buffer::{AutoCommandBufferBuilder, DynamicState, PrimaryAutoCommandBuffer},
     render_pass::RenderPass,
 };
+use crate::eval::layout::RenderObjectOrSubPass;
 
 pub struct RawRenderer {
     render_pass: Arc<RenderPass>,
@@ -15,9 +17,9 @@ impl RawRenderer {
         buffer_builder: &mut AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>,
         dynamic_state: &DynamicState,
         dimensions: &[u32; 2],
-        render_object: &PositionedRenderObject<'a>,
+        render_object: &PositionedElement<'a>,
     ) {
-        if let RenderObject::Raw { render_fn } = &render_object.render_object {
+        if let RenderObjectOrSubPass::RenderObject(RenderObject::Raw { render_fn }) = &render_object.element {
             render_fn(
                 self.render_pass.clone(),
                 buffer_builder,
@@ -28,3 +30,4 @@ impl RawRenderer {
         }
     }
 }
+*/

--- a/narui_core/src/vulkano_render/subpass_stack.rs
+++ b/narui_core/src/vulkano_render/subpass_stack.rs
@@ -1,0 +1,463 @@
+use crate::{
+    eval::layout::{PositionedElement, RenderObjectOrSubPass},
+    vulkano_render::primitive_renderer::RenderData,
+    CallbackContext,
+    Rect,
+    RenderFnInner,
+    RenderObject,
+    SubPassRenderFunction,
+    Vec2,
+};
+use derivative::Derivative;
+use std::{fmt::Formatter, sync::Arc};
+use vulkano::{
+    buffer::{BufferAccess, TypedBufferAccess},
+    command_buffer::{
+        AutoCommandBufferBuilder,
+        CommandBufferUsage::OneTimeSubmit,
+        PrimaryAutoCommandBuffer,
+        SubpassContents,
+    },
+    device::{DeviceOwned, Queue},
+    format::{ClearValue, Format},
+    image::{
+        view::ImageView,
+        AttachmentImage,
+        ImageAccess,
+        ImageUsage,
+        ImageViewAbstract,
+        SampleCount::Sample2,
+    },
+    pipeline::viewport::Viewport,
+    render_pass::{Framebuffer, FramebufferAbstract, RenderPass},
+};
+
+// render function, color, depth, absolute layout rect, z_index
+type Finisher = (SubPassRenderFunction, AbstractImageView, AbstractImageView, Rect, u32);
+
+struct SubPassData {
+    fb: AbstractFramebuffer,
+    intermediary: AbstractImage,
+    depth_image: AbstractImage,
+    // only None at the first "virtual" (toplevel) subpass
+    depth: Option<AbstractImageView>,
+    color: Option<AbstractImageView>,
+    rect: Rect,
+    first: usize,
+    first_use: bool,
+    finishers: Vec<Finisher>,
+}
+
+fn opaque_fmt<T>(o: &Option<T>, fmt: &mut Formatter) -> std::fmt::Result {
+    if o.is_some() {
+        write!(fmt, "Some(..)")
+    } else {
+        write!(fmt, "None")
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub enum SubPassRenderCommand {
+    RenderPrimitive {
+        #[derivative(Debug = "ignore")]
+        target: AbstractFramebuffer,
+        offset: Vec2,
+        start: usize,
+        end: usize, // exclusive
+        #[derivative(Debug(format_with = "opaque_fmt"))]
+        to_clear: Option<(AbstractImage, AbstractImage)>,
+    },
+    Raw {
+        #[derivative(Debug = "ignore")]
+        target: AbstractFramebuffer,
+        #[derivative(Debug = "ignore")]
+        fun: Arc<RenderFnInner>,
+        z_index: u32,
+        rect: Rect,
+        clipping_rect: Option<Rect>,
+        #[derivative(Debug(format_with = "opaque_fmt"))]
+        to_clear: Option<(AbstractImage, AbstractImage)>,
+    },
+    ResolveOrFinish {
+        #[derivative(Debug = "ignore")]
+        resolve: SubPassRenderFunction,
+        #[derivative(Debug = "ignore")]
+        depth: AbstractImageView,
+        #[derivative(Debug = "ignore")]
+        color: AbstractImageView,
+        #[derivative(Debug = "ignore")]
+        to: AbstractFramebuffer,
+        abs_rect: Rect,
+        rect: Rect,
+        z_index: u32,
+        #[derivative(Debug(format_with = "opaque_fmt"))]
+        to_clear: Option<(AbstractImage, AbstractImage)>,
+    },
+}
+
+pub type AbstractImageView = Arc<dyn ImageViewAbstract + Send + Sync>;
+pub type AbstractFramebuffer = Arc<dyn FramebufferAbstract + Send + Sync>;
+pub type AbstractImage = Arc<dyn ImageAccess + Send + Sync>;
+
+pub struct SubPassStack {
+    queue: Arc<Queue>,
+    format: Format,
+    render_pass: Arc<RenderPass>,
+    stack: Vec<SubPassData>,
+    pub(crate) render_commands: Vec<SubPassRenderCommand>,
+}
+
+impl SubPassStack {
+    pub fn new(
+        format: Format,
+        queue: Arc<Queue>,
+        render_pass: Arc<RenderPass>,
+        toplevel_fb: AbstractFramebuffer,
+        toplevel_intermediary: AbstractImage,
+        toplevel_depth: AbstractImage,
+    ) -> Self {
+        let stack = vec![SubPassData {
+            fb: toplevel_fb,
+            intermediary: toplevel_intermediary,
+            depth_image: toplevel_depth,
+            depth: None,
+            color: None,
+            rect: Rect::zero(),
+            first: 0,
+            first_use: true,
+            finishers: vec![],
+        }];
+        Self { format, queue, render_pass, stack, render_commands: vec![] }
+    }
+}
+
+pub fn create_framebuffer<I: ImageAccess + Send + Sync + 'static>(
+    size: [u32; 2],
+    render_pass: Arc<RenderPass>,
+    format: Format,
+    target_image: Option<I>,
+) -> (AbstractFramebuffer, AbstractImageView, AbstractImageView, AbstractImage, AbstractImage) {
+    let intermediary_image = AttachmentImage::multisampled_with_usage(
+        render_pass.device().clone(),
+        size,
+        Sample2,
+        format,
+        ImageUsage { color_attachment: true, transfer_destination: true, ..ImageUsage::none() },
+    )
+    .unwrap();
+    let intermediary = ImageView::new(intermediary_image.clone()).unwrap();
+
+    let target = match target_image {
+        Some(i) => ImageView::new(i).unwrap() as AbstractImageView,
+        None => ImageView::new(
+            AttachmentImage::with_usage(
+                render_pass.device().clone(),
+                size,
+                format,
+                ImageUsage {
+                    color_attachment: true,
+                    sampled: true,
+                    transfer_destination: true,
+                    ..ImageUsage::none()
+                },
+            )
+            .unwrap(),
+        )
+        .unwrap() as AbstractImageView,
+    };
+
+    let depth_image = AttachmentImage::multisampled_with_usage(
+        render_pass.device().clone(),
+        size,
+        Sample2,
+        Format::D16_UNORM,
+        ImageUsage {
+            depth_stencil_attachment: true,
+            sampled: true,
+            transfer_destination: true,
+            ..ImageUsage::none()
+        },
+    )
+    .unwrap();
+
+    let depth = ImageView::new(depth_image.clone()).unwrap();
+
+    (
+        Arc::new(
+            Framebuffer::start(render_pass)
+                .add(intermediary)
+                .unwrap()
+                .add(depth.clone())
+                .unwrap()
+                .add(target.clone())
+                .unwrap()
+                .build()
+                .unwrap(),
+        ) as AbstractFramebuffer,
+        depth,
+        target,
+        intermediary_image,
+        depth_image,
+    )
+}
+
+impl SubPassStack {
+    fn push_render_primitive(&mut self, data: &RenderData) {
+        let pass = self.stack.last().unwrap();
+        let rect = pass.rect;
+        let first = pass.first;
+        if pass.first != data.indices.len() {
+            self.push_command(data, |target, to_clear| SubPassRenderCommand::RenderPrimitive {
+                offset: rect.pos,
+                target,
+                start: first,
+                end: data.indices.len(),
+                to_clear,
+            });
+        }
+    }
+
+    fn push_command<
+        F: FnOnce(AbstractFramebuffer, Option<(AbstractImage, AbstractImage)>) -> SubPassRenderCommand,
+    >(
+        &mut self,
+        data: &RenderData,
+        fun: F,
+    ) {
+        let pass = self.stack.last_mut().unwrap();
+        let (to_clear, target) = (
+            if pass.first_use {
+                Some((pass.intermediary.clone(), pass.depth_image.clone()))
+            } else {
+                None
+            },
+            pass.fb.clone(),
+        );
+
+        pass.first = data.indices.len();
+        pass.first_use = false;
+        self.render_commands.push(fun(target, to_clear));
+    }
+
+    fn push_finishers(&mut self, data: &RenderData, offset: Vec2, finishers: &[Finisher]) {
+        for (finish, color, depth, rect, z_index) in finishers {
+            self.push_command(data, |target, to_clear| SubPassRenderCommand::ResolveOrFinish {
+                resolve: finish.clone(),
+                color: color.clone(),
+                depth: depth.clone(),
+                to: target,
+                abs_rect: *rect,
+                rect: rect.minus_position(offset),
+                z_index: *z_index,
+                to_clear,
+            });
+        }
+    }
+
+    pub fn handle(&mut self, data: &RenderData, obj: &PositionedElement) {
+        match &obj.element {
+            RenderObjectOrSubPass::SubPassPush => {
+                self.push_render_primitive(data);
+                let (fb, depth, color, intermediary, depth_image) =
+                    create_framebuffer::<AttachmentImage>(
+                        obj.rect.size.pixels(),
+                        self.render_pass.clone(),
+                        self.format,
+                        None,
+                    );
+                self.stack.push(SubPassData {
+                    fb,
+                    intermediary,
+                    depth: Some(depth),
+                    color: Some(color),
+                    depth_image,
+                    rect: obj.rect,
+                    first: data.indices.len(),
+                    first_use: true,
+                    finishers: vec![],
+                });
+            }
+            RenderObjectOrSubPass::SubPassPop(setup) => {
+                self.push_render_primitive(data);
+                let pass = self.stack.pop().unwrap();
+
+                let offset = self.stack.last().unwrap().rect.pos;
+                self.push_finishers(data, offset, &pass.finishers[..]);
+
+                let color = pass.color.unwrap().clone();
+                let depth = pass.depth.unwrap().clone();
+                self.push_command(data, |target, to_clear| SubPassRenderCommand::ResolveOrFinish {
+                    resolve: setup.resolve.clone(),
+                    color: color.clone(),
+                    depth: depth.clone(),
+                    to: target,
+                    abs_rect: obj.rect,
+                    rect: obj.rect.minus_position(offset),
+                    z_index: obj.z_index,
+                    to_clear,
+                });
+
+                if let Some((finish, target)) = &setup.finish {
+                    let target = match target {
+                        Some(offset) => {
+                            let pos = self.stack.len() - 1 - offset;
+                            &mut self.stack[pos]
+                        }
+                        None => self.stack.last_mut().unwrap(),
+                    };
+                    target.finishers.push((finish.clone(), color, depth, obj.rect, obj.z_index));
+                }
+            }
+            RenderObjectOrSubPass::RenderObject(RenderObject::Raw { render_fn }) => {
+                self.push_render_primitive(data);
+                self.push_command(data, |target, to_clear| SubPassRenderCommand::Raw {
+                    target,
+                    fun: render_fn.clone(),
+                    z_index: obj.z_index,
+                    rect: obj.rect,
+                    clipping_rect: obj.clipping_rect,
+                    to_clear,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    pub fn finish(&mut self, data: &RenderData) {
+        self.push_render_primitive(data);
+        let finishers = std::mem::take(&mut self.stack.last_mut().unwrap().finishers);
+        self.push_finishers(data, Vec2::zero(), &finishers[..]);
+    }
+    pub fn render<F>(
+        &mut self,
+        callback_context: &CallbackContext,
+        primitive_renderer: F,
+        vertex_buffer: impl BufferAccess + Clone + 'static,
+        index_buffer: impl BufferAccess + TypedBufferAccess<Content = [u32]> + Clone + 'static,
+    ) -> PrimaryAutoCommandBuffer
+    where
+        F: Fn(
+            &mut AutoCommandBufferBuilder<PrimaryAutoCommandBuffer>,
+            &Viewport,
+            &[u32; 2],
+            Vec2,
+            u64,
+            u64,
+        ),
+    {
+        log::trace!("collected render commands {:?}", self.render_commands);
+
+        let mut builder = AutoCommandBufferBuilder::primary(
+            self.render_pass.device().clone(),
+            self.queue.family(),
+            OneTimeSubmit,
+        )
+        .unwrap();
+
+        let mut viewport =
+            Viewport { origin: [0.0, 0.0], dimensions: [1.0, 1.0], depth_range: 0.0..1.0 };
+        let mut dimensions = [0, 0];
+
+        macro_rules! push_render_pass {
+            ($builder:ident, $target:ident, $viewport:ident, $dimensions:ident, $to_clear:ident $(, $secondary:expr)?) => {
+                let clear_values = vec![ClearValue::None, ClearValue::None, ClearValue::None];
+                // let clear_values = vec![[0., 0., 1., 1.].into(), 1f32.into(), ClearValue::None];
+                let dims = $target.attached_image_view(0).unwrap().image().dimensions();
+                $dimensions = [dims.width(), dims.height()];
+                $viewport = Viewport {
+                    origin: [0.0, 0.0],
+                    dimensions: [dimensions[0] as f32, dimensions[1] as f32],
+                    depth_range: 0.0..1.0,
+                };
+
+                if let Some((color, depth)) = $to_clear {
+                    $builder.clear_color_image(color, [0., 0., 0., 0.].into()).unwrap();
+                    $builder.clear_depth_stencil_image(depth, 1.0.into()).unwrap();
+                }
+
+                push_render_pass!(@finish clear_values, $builder, $target $(, $secondary)?);
+            };
+            (@finish $clear_values:ident, $builder:ident, $target:ident, $secondary:expr) => {
+                $builder
+                    .begin_render_pass($target.clone(), SubpassContents::SecondaryCommandBuffers, $clear_values.clone())
+                    .unwrap();
+
+                $builder.execute_commands($secondary).unwrap();
+
+                $builder.end_render_pass().unwrap();
+            };
+            (@finish $clear_values:ident, $builder:ident, $target:ident) => {
+                $builder
+                    .begin_render_pass($target.clone(), SubpassContents::Inline, $clear_values).unwrap()
+                    .bind_vertex_buffers(0, (vertex_buffer.clone()))
+                    .bind_index_buffer(index_buffer.clone());
+            };
+        }
+
+        for command in self.render_commands.drain(..) {
+            match command {
+                SubPassRenderCommand::RenderPrimitive { target, offset, start, end, to_clear } => {
+                    push_render_pass!(builder, target, viewport, dimensions, to_clear);
+                    primitive_renderer(
+                        &mut builder,
+                        &viewport,
+                        &dimensions,
+                        offset,
+                        start as _,
+                        end as _,
+                    );
+                    builder.end_render_pass().unwrap();
+                }
+                SubPassRenderCommand::Raw {
+                    target,
+                    fun,
+                    z_index,
+                    rect,
+                    clipping_rect: _,
+                    to_clear,
+                } => {
+                    push_render_pass!(
+                        builder,
+                        target,
+                        viewport,
+                        dimensions,
+                        to_clear,
+                        fun(&viewport, 1.0 - z_index as f32 / 65535.0, rect, dimensions.into(),)
+                    );
+                }
+                SubPassRenderCommand::ResolveOrFinish {
+                    resolve,
+                    depth,
+                    color,
+                    to,
+                    abs_rect,
+                    rect,
+                    z_index,
+                    to_clear,
+                } => {
+                    push_render_pass!(
+                        builder,
+                        to,
+                        viewport,
+                        dimensions,
+                        to_clear,
+                        resolve(
+                            callback_context,
+                            color,
+                            depth,
+                            self.render_pass.clone(),
+                            viewport.clone(),
+                            dimensions,
+                            abs_rect,
+                            rect,
+                            1.0 - z_index as f32 / 65535.0,
+                        )
+                    );
+                }
+            }
+        }
+
+        builder.build().unwrap()
+    }
+}

--- a/narui_macros/src/lib.rs
+++ b/narui_macros/src/lib.rs
@@ -39,6 +39,7 @@ pub fn rsx_toplevel(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     children: #narui::smallvec![ #rsx ],
                     layout: Box::new(#narui::Transparent),
                     is_clipper: false,
+                    subpass: None
                 }
             })),
         }

--- a/narui_widgets/Cargo.toml
+++ b/narui_widgets/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 [dependencies]
 narui = { path = "../narui_core", package = "narui_core" }
 narui_macros = { path = "../narui_macros" }
+vulkano = { git = "https://github.com/vulkano-rs/vulkano" }
+vulkano-shaders = { git = "https://github.com/vulkano-rs/vulkano" }

--- a/narui_widgets/src/controls.rs
+++ b/narui_widgets/src/controls.rs
@@ -19,7 +19,7 @@ pub fn button(
         color
     };
 
-    let callback = move |context: &CallbackContext, is_clicked| {
+    let callback = move |context: &CallbackContext, is_clicked, _, _| {
         context.shout(clicked, is_clicked);
         if is_clicked {
             on_click(context);
@@ -55,9 +55,10 @@ pub fn slider(
 ) -> Fragment {
     let widget_key = context.widget_local.idx;
     let clicked = context.listenable(false);
-    let on_click = move |context: &CallbackContext, is_clicked| context.shout(clicked, is_clicked);
+    let on_click =
+        move |context: &CallbackContext, is_clicked, _, _| context.shout(clicked, is_clicked);
 
-    let on_move = move |context: &CallbackContext, position: Vec2| {
+    let on_move = move |context: &CallbackContext, position: Vec2, _| {
         let clicked = context.spy(clicked);
         let width = context.measure_size(widget_key).unwrap().x - 20.0;
 

--- a/narui_widgets/src/fragment.rs
+++ b/narui_widgets/src/fragment.rs
@@ -7,5 +7,6 @@ pub fn fragment(children: Option<Fragment>, context: &mut WidgetContext) -> Frag
         children: children.into_iter().collect(),
         layout: Box::new(Transparent),
         is_clipper: false,
+        subpass: None,
     }
 }

--- a/narui_widgets/src/input.rs
+++ b/narui_widgets/src/input.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 #[widget]
 pub fn input_leaf(
-    #[default] on_click: impl for<'a> Fn(&'a CallbackContext, bool) + Clone + 'static,
-    #[default] on_hover: impl for<'a> Fn(&'a CallbackContext, bool) + Clone + 'static,
-    #[default] on_move: impl for<'a> Fn(&'a CallbackContext, Vec2) + Clone + 'static,
+    #[default] on_click: impl for<'a> Fn(&'a CallbackContext, bool, Vec2, Vec2) + Clone + 'static,
+    #[default] on_hover: impl for<'a> Fn(&'a CallbackContext, bool, Vec2, Vec2) + Clone + 'static,
+    #[default] on_move: impl for<'a> Fn(&'a CallbackContext, Vec2, Vec2) + Clone + 'static,
     context: &mut WidgetContext,
 ) -> FragmentInner {
     FragmentInner::Leaf {
@@ -25,9 +25,9 @@ pub fn input_leaf(
 #[widget]
 pub fn input(
     children: Fragment,
-    #[default] on_click: impl for<'a> Fn(&'a CallbackContext, bool) + Clone + 'static,
-    #[default] on_hover: impl for<'a> Fn(&'a CallbackContext, bool) + Clone + 'static,
-    #[default] on_move: impl for<'a> Fn(&'a CallbackContext, Vec2) + Clone + 'static,
+    #[default] on_click: impl for<'a> Fn(&'a CallbackContext, bool, Vec2, Vec2) + Clone + 'static,
+    #[default] on_hover: impl for<'a> Fn(&'a CallbackContext, bool, Vec2, Vec2) + Clone + 'static,
+    #[default] on_move: impl for<'a> Fn(&'a CallbackContext, Vec2, Vec2) + Clone + 'static,
     context: &mut WidgetContext,
 ) -> Fragment {
     rsx! {

--- a/narui_widgets/src/layout.rs
+++ b/narui_widgets/src/layout.rs
@@ -13,6 +13,7 @@ pub fn column(
         children,
         layout: Box::new(Column { cross_axis_alignment, main_axis_alignment, main_axis_size }),
         is_clipper: false,
+        subpass: None,
     }
 }
 
@@ -28,6 +29,7 @@ pub fn row(
         children,
         layout: Box::new(Row { cross_axis_alignment, main_axis_alignment, main_axis_size }),
         is_clipper: false,
+        subpass: None,
     }
 }
 
@@ -42,6 +44,7 @@ pub fn flexible(
         children: smallvec![children],
         layout: Box::new(Flexible { flex: Flex { flex, fit } }),
         is_clipper: false,
+        subpass: None,
     }
 }
 
@@ -55,6 +58,7 @@ pub fn padding(
         children: smallvec![children],
         layout: Box::new(Padding::new(padding)),
         is_clipper: false,
+        subpass: None,
     }
 }
 
@@ -70,6 +74,7 @@ pub fn align(
         children: smallvec![children],
         layout: Box::new(Align::fractional(alignment, factor_width, factor_height)),
         is_clipper: false,
+        subpass: None,
     }
 }
 
@@ -83,6 +88,7 @@ pub fn sized(
         children: children.into_iter().collect(),
         layout: Box::new(SizedBox::constrained(constraint)),
         is_clipper: false,
+        subpass: None,
     }
 }
 
@@ -94,18 +100,39 @@ pub fn stack(
     #[default] is_clipper: bool,
     context: &mut WidgetContext,
 ) -> FragmentInner {
-    FragmentInner::Node { children, layout: Box::new(Stack { fit, alignment }), is_clipper }
+    FragmentInner::Node {
+        children,
+        layout: Box::new(Stack { fit, alignment }),
+        is_clipper,
+        subpass: None,
+    }
 }
 
 #[widget]
 pub fn positioned(
     children: Fragment,
     #[default] pos: AbsolutePosition,
+    #[default(false)] z_top: bool,
     context: &mut WidgetContext,
 ) -> FragmentInner {
     FragmentInner::Node {
         children: smallvec![children],
-        layout: Box::new(Positioned::new(pos)),
+        layout: Box::new(if z_top { Positioned::z_top(pos) } else { Positioned::new(pos) }),
         is_clipper: false,
+        subpass: None,
+    }
+}
+
+#[widget]
+pub fn aspect_ratio(
+    children: Option<Fragment>,
+    aspect_ratio: f32,
+    context: &mut WidgetContext,
+) -> FragmentInner {
+    FragmentInner::Node {
+        children: children.into_iter().collect(),
+        layout: Box::new(AspectRatioBox::new(AspectRatio { ratio: aspect_ratio })),
+        is_clipper: false,
+        subpass: None,
     }
 }

--- a/narui_widgets/src/lib.rs
+++ b/narui_widgets/src/lib.rs
@@ -21,5 +21,8 @@ pub use text_widget::*;
 mod input_widget;
 pub use input_widget::*;
 
+#[path = "subpass.rs"]
+mod subpass_widget;
+pub use subpass_widget::*;
 
 pub mod theme;

--- a/narui_widgets/src/rect.rs
+++ b/narui_widgets/src/rect.rs
@@ -17,6 +17,7 @@ pub fn rect_leaf(
             stroke_width: stroke.map(|v| v.1).unwrap_or(0.0),
             border_radius,
             inverted: false,
+            for_clipping: false,
         },
         layout: Box::new(Maximal),
     }
@@ -27,6 +28,7 @@ pub fn rect_leaf(
 pub fn inverse_rect_leaf(
     #[default] border_radius: Dimension,
     #[default] fill: Option<Color>,
+    #[default(false)] for_clipping: bool,
     context: &mut WidgetContext,
 ) -> FragmentInner {
     FragmentInner::Leaf {
@@ -35,6 +37,7 @@ pub fn inverse_rect_leaf(
             stroke_color: None,
             fill_color: fill,
             stroke_width: 0.0,
+            for_clipping,
             border_radius,
         },
         layout: Box::new(Maximal),
@@ -69,13 +72,13 @@ pub fn rect(
     } else {
         rsx! {
             <stack is_clipper=true>
+                <positioned z_top=true>
+                    <inverse_rect_leaf fill=Some(Color::new(0., 0., 0., 0.)) border_radius=border_radius for_clipping=true />
+                </positioned>
                 <positioned>
                     <rect_leaf border_radius=border_radius fill=fill stroke=stroke />
                 </positioned>
                 <sized constraint=constraint>{children}</sized>
-                <positioned>
-                    <inverse_rect_leaf fill=Some(Color::new(0., 0., 0., 0.)) border_radius=border_radius />
-                </positioned>
             </stack>
         }
     }

--- a/narui_widgets/src/subpass.rs
+++ b/narui_widgets/src/subpass.rs
@@ -1,0 +1,317 @@
+use narui::{
+    layout::Transparent,
+    re_export::smallvec::smallvec,
+    CallbackContext,
+    ContextEffect,
+    ContextMeasure,
+    Fragment,
+    FragmentInner,
+    Rect,
+    SubPassRenderFunction,
+    SubPassSetup,
+    Vec2,
+    WidgetContext,
+};
+use narui_macros::{rsx, widget};
+use std::sync::Arc;
+use vulkano::{
+    command_buffer::{AutoCommandBufferBuilder, CommandBufferUsage},
+    descriptor_set::PersistentDescriptorSet,
+    device::{DeviceOwned, Queue},
+    pipeline::{
+        blend::{AttachmentBlend, BlendFactor, BlendOp},
+        depth_stencil::{Compare, DepthStencil},
+        GraphicsPipeline,
+        PipelineBindPoint,
+    },
+    render_pass::Subpass,
+    sampler::{Filter, MipmapMode, Sampler, SamplerAddressMode},
+};
+
+mod vertex_shader {
+    vulkano_shaders::shader! {
+        ty: "vertex",
+        src: "
+            #version 450
+            #extension GL_EXT_debug_printf: enable
+            layout(push_constant) uniform PushConstantData {
+                uint width;
+                uint height;
+                float z_index;
+                vec2 origin;
+                vec2 size;
+                ivec2 direction;
+                vec3 coeffs;
+                vec2 window_min;
+                vec2 window_max;
+            } params;
+
+            layout(location = 0) out vec2 origin;
+            layout(location = 1) out ivec2 direction;
+            layout(location = 2) out vec3 coeffs;
+            layout(location = 3) out vec2 window_min;
+            layout(location = 4) out vec2 window_max;
+
+            void main() {
+                int idx = gl_VertexIndex;
+                int top = idx & 1;
+                int left = (idx & 2) / 2;
+
+                origin = params.origin;
+                coeffs = params.coeffs;
+                direction = params.direction;
+                window_min = params.window_min;
+                window_max = params.window_max;
+
+                vec2 pos = params.origin + vec2(top, left) * params.size;
+                pos = (pos / (vec2(params.width, params.height) / 2.) - vec2(1.));
+                gl_Position = vec4(pos, params.z_index, 1.0);
+            }
+        "
+    }
+}
+mod fragment_shader {
+    vulkano_shaders::shader! {
+        ty: "fragment",
+        src: "
+            #version 450
+            #extension GL_EXT_debug_printf: enable
+            layout(location = 0) out vec4 f_color;
+            layout(set = 0, binding = 0) uniform sampler2DMS depth;
+            layout(set = 0, binding = 1) uniform sampler2D color;
+
+            layout(location = 0) flat in vec2 origin;
+            layout(location = 1) flat in ivec2 direction;
+            layout(location = 2) flat in vec3 coeffs;
+            layout(location = 3) flat in vec2 window_min;
+            layout(location = 4) flat in vec2 window_max;
+
+            void main() {
+                ivec2 pos = ivec2(gl_FragCoord.xy - origin);
+
+                if (pos.x < window_min.x || pos.y < window_min.y
+                 || pos.x > window_max.x || pos.y > window_max.y) {
+                    f_color = texelFetch(color, pos, 0);
+                } else {
+                    float sigma = (1. / coeffs.x) / sqrt(2. * 3.14159265358979361);
+                    float sampleCount = ceil(1.5 * sigma);
+
+                    vec3 g = coeffs;
+                    ivec2 size = textureSize(color, 0) - 1;
+                    vec4 color_sum = texelFetch(color, pos, 0) * g.x;
+                    float coeff_norm = g.x;
+                    for (int i = 1; i < sampleCount; i++) {
+                        g.xy *= g.yz;
+                        color_sum += texelFetch(color, min(pos + i * direction, size), 0) * g.x;
+                        color_sum += texelFetch(color, max(pos - i * direction, ivec2(0)), 0) * g.x;
+                        coeff_norm += 2.0 * g.x;
+                    }
+                    vec4 color = color_sum / coeff_norm;
+                    f_color = vec4(color.rgb * color.w, color.w);
+                }
+            }
+        "
+    }
+}
+
+#[widget]
+pub fn raw_blur(
+    children: Fragment,
+    window: Option<Fragment>,
+    sigma: f32,
+    in_x: bool,
+    backdrop_after: Option<usize>,
+    context: &mut WidgetContext,
+) -> FragmentInner {
+    let pipeline_and_sampler = context.effect(
+        |context| {
+            let render_pass = context.vulkan_context.render_pass.clone();
+            let vs = vertex_shader::Shader::load(render_pass.device().clone()).unwrap();
+            let fs = fragment_shader::Shader::load(render_pass.device().clone()).unwrap();
+            let pipeline = Arc::new(
+                GraphicsPipeline::start()
+                    .vertex_shader(vs.main_entry_point(), ())
+                    .triangle_strip()
+                    .viewports_dynamic_scissors_irrelevant(1)
+                    .fragment_shader(fs.main_entry_point(), ())
+                    .blend_collective(AttachmentBlend {
+                        enabled: true,
+                        color_op: BlendOp::Add,
+                        color_source: BlendFactor::SrcAlpha,
+                        color_destination: BlendFactor::OneMinusSrcAlpha,
+                        alpha_op: BlendOp::Max,
+                        alpha_source: BlendFactor::One,
+                        alpha_destination: BlendFactor::One,
+                        mask_red: true,
+                        mask_green: true,
+                        mask_blue: true,
+                        mask_alpha: true,
+                    })
+                    .depth_stencil(DepthStencil {
+                        depth_compare: Compare::LessOrEqual,
+                        ..DepthStencil::simple_depth_test()
+                    })
+                    .render_pass(Subpass::from(render_pass.clone(), 0).unwrap())
+                    .build(render_pass.device().clone())
+                    .unwrap(),
+            );
+
+            let sampler = Sampler::new(
+                render_pass.device().clone(),
+                Filter::Nearest,
+                Filter::Nearest,
+                MipmapMode::Nearest,
+                SamplerAddressMode::ClampToEdge,
+                SamplerAddressMode::ClampToEdge,
+                SamplerAddressMode::ClampToEdge,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+            )
+            .unwrap();
+
+            (pipeline, sampler)
+        },
+        (),
+    );
+    let pipeline_and_sampler = pipeline_and_sampler.read();
+    let pipeline = pipeline_and_sampler.0.clone();
+    let sampler = pipeline_and_sampler.1.clone();
+    let queue = context
+        .vulkan_context
+        .queues
+        .iter()
+        .find(|&q| q.family().supports_graphics())
+        .unwrap()
+        .clone();
+
+    fn generate_resolve(
+        in_x: bool,
+        sigma: f32,
+        pipeline: Arc<GraphicsPipeline>,
+        sampler: Arc<Sampler>,
+        queue: Arc<Queue>,
+        window_function: impl Fn(&CallbackContext, Rect, Rect) -> Rect + 'static,
+    ) -> SubPassRenderFunction {
+        std::rc::Rc::new(
+            move |context,
+                  color,
+                  depth,
+                  render_pass,
+                  viewport,
+                  dimensions,
+                  abs_pos,
+                  rect,
+                  z_index| {
+                let window = window_function(context, abs_pos, rect);
+
+                let mut set_builder = PersistentDescriptorSet::start(
+                    pipeline.layout().descriptor_set_layouts()[0].clone(),
+                );
+                set_builder
+                    .add_sampled_image(depth, sampler.clone())
+                    .unwrap()
+                    .add_sampled_image(color, sampler.clone())
+                    .unwrap();
+                let descriptor_set = Arc::new(set_builder.build().unwrap());
+
+                let coeff_a = 1.0 / ((2.0f32 * 3.151_592_3).sqrt() * sigma);
+                let coeff_b = (-0.5 / (sigma * sigma)).exp();
+                let coeff_c = coeff_b * coeff_b;
+
+                let push_constants = vertex_shader::ty::PushConstantData {
+                    width: dimensions[0],
+                    height: dimensions[1],
+                    z_index,
+                    origin: rect.pos.into(),
+                    size: rect.size.into(),
+                    coeffs: [coeff_a, coeff_b, coeff_c],
+                    direction: if in_x { [1, 0] } else { [0, 1] },
+                    window_min: window.top_left_corner().into(),
+                    window_max: window.bottom_right_corner().into(),
+                    _dummy0: Default::default(),
+                    _dummy1: Default::default(),
+                    _dummy2: Default::default(),
+                };
+
+                let mut builder = AutoCommandBufferBuilder::secondary_graphics(
+                    render_pass.device().clone(),
+                    queue.family(),
+                    CommandBufferUsage::MultipleSubmit,
+                    pipeline.subpass().clone(),
+                )
+                .unwrap();
+                builder
+                    .bind_descriptor_sets(
+                        PipelineBindPoint::Graphics,
+                        pipeline.layout().clone(),
+                        0,
+                        descriptor_set,
+                    )
+                    .bind_pipeline_graphics(pipeline.clone())
+                    .push_constants(pipeline.layout().clone(), 0, push_constants)
+                    .set_viewport(0, std::iter::once(viewport))
+                    .draw(4, 1, 0, 0)
+                    .unwrap();
+
+                builder.build().unwrap()
+            },
+        )
+    }
+
+    let resolve = generate_resolve(
+        in_x,
+        sigma,
+        pipeline.clone(),
+        sampler.clone(),
+        queue.clone(),
+        move |context, abs_pos, rect| match window {
+            Some(frag) => {
+                let window_rect = context.measure(frag).unwrap();
+                window_rect.minus_position(abs_pos.pos)
+            }
+            None => Rect::from_corners(Vec2::zero(), rect.size),
+        },
+    );
+
+    let finish =
+        generate_resolve(in_x, sigma, pipeline, sampler, queue, move |_, _, _| Rect::zero());
+
+    FragmentInner::Node {
+        children: smallvec![children],
+        layout: Box::new(Transparent),
+        is_clipper: false,
+        subpass: Some(SubPassSetup {
+            resolve,
+            finish: backdrop_after.map(|after| (finish, Some(after))),
+        }),
+    }
+}
+
+#[widget]
+pub fn blur(
+    children: Fragment,
+    #[default] window: Option<Fragment>,
+    sigma: f32,
+    context: &mut WidgetContext,
+) -> Fragment {
+    rsx! {
+        <raw_blur sigma=sigma in_x=true window=window backdrop_after=None>
+            <raw_blur sigma=sigma in_x=false window=window backdrop_after=None>
+                {children}
+            </raw_blur>
+        </raw_blur>
+    }
+}
+
+#[widget]
+pub fn backdrop_blur(children: Fragment, sigma: f32, context: &mut WidgetContext) -> Fragment {
+    rsx! {
+        <raw_blur sigma=sigma in_x=true window=None backdrop_after=None>
+            <raw_blur sigma=sigma in_x=false window=None backdrop_after=Some(1)>
+                {children}
+            </raw_blur>
+        </raw_blur>
+    }
+}

--- a/rutter_layout/Cargo.toml
+++ b/rutter_layout/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 [dependencies]
 freelist = { path = "../freelist" }
 
-hashbrown = "0.11.2"
 derivative = "2.2.0"
+log = "*"

--- a/rutter_layout/src/layouts/basic.rs
+++ b/rutter_layout/src/layouts/basic.rs
@@ -335,7 +335,7 @@ impl FractionallySizedBox {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AspectRatio {
     // width / height
-    ratio: f32,
+    pub ratio: f32,
 }
 
 impl AspectRatio {
@@ -344,6 +344,7 @@ impl AspectRatio {
     fn height_for(self, width: f32) -> f32 { width / self.ratio }
 
     fn target_size(self, input_constraint: BoxConstraints) -> Size {
+        log::trace!("got input {:?}, aspect ratio = {}", input_constraint, self.ratio);
         assert!(input_constraint.width_is_bounded() || input_constraint.height_is_bounded());
 
         let width = if input_constraint.width_is_bounded() {
@@ -351,12 +352,15 @@ impl AspectRatio {
         } else {
             self.width_for(input_constraint.max_height).min(input_constraint.max_width)
         };
+        log::trace!("initial guess for width: {}", width);
         let height = self.height_for(width).min(input_constraint.max_height);
+        log::trace!("now got height {}", height);
         // TODO(robin): flutter does these, but I don't think these actually do
         // anything? let width =
         // self.width_for(height).max(input_constraint.min_width); let height =
         // self.height_for(width).max(input_constraint.min_height);
         let width = self.width_for(height);
+        log::trace!("and fixing up width to it {}", width);
 
         Size { width, height }
     }

--- a/rutter_layout/src/types.rs
+++ b/rutter_layout/src/types.rs
@@ -44,6 +44,14 @@ impl BoxConstraints {
         Self { min_width: width, max_width: width, min_height: height, max_height: height }
     }
 
+    pub fn tight_width(width: f32) -> Self {
+        Self { min_width: width, max_width: width, min_height: 0., max_height: f32::INFINITY }
+    }
+
+    pub fn tight_height(height: f32) -> Self {
+        Self { min_width: 0., max_width: f32::INFINITY, min_height: height, max_height: height }
+    }
+
     pub fn tighten(self) -> Self {
         Self { min_width: self.max_width, min_height: self.max_height, ..self }
     }


### PR DESCRIPTION
This implements arbitrary subpass rendering meaning:
There is a new type of `Fragment`, a `Fragment::Node` with a `subpass_resolve` function.
The rendering of this type of `Fragment` is defined to first render all its children on a seperate `Framebuffer` and then render this framebuffer onto the "next higher" `Framebuffer` with a user defined `subpass_resolve` function, which gets the `color` and `depth` attachments of the child `Framebuffer` as inputs and can then emit arbitrary vulkan draw calls.

As a side artifact, this also now has the probper draw order for`Text` and `Raw` `RenderObject`s.

Open questions:
- do we need any synchronization between the multiple renderpasses? -> **NO**
- does this interact correctly with clipping?
- does this currently properly render `Raw` `RenderObject`s? 
- how do downstream widgets properly cache the pipeline, etc? -> we store the `device`, `renderpass` and `queue` in the `context` and the widgets can use `context.effect` to cache them. 
- should we be using sub commandbuffers? (Then we could simply return a command buffer from the `subpass_resolve` function, and we should be able to bind our own index and vertex buffers (if this is ever necessary). -> **YES**
- do we want partial redraws, using the subpasses as natural boundaries? -> **LATER**
- is there any way to do this without `vulkano` from git? (The `BufferAccess::slice` function stores a reference to the original buffer and not something like a `Arc` :()