### PR TITLE
Macro rework

### DIFF
--- a/examples/blur.rs
+++ b/examples/blur.rs
@@ -32,21 +32,19 @@ pub fn draggable_rect(initial_pos: Vec2, context: &mut WidgetContext) -> Fragmen
 #[widget]
 pub fn top(context: &mut WidgetContext) -> Fragment {
     rsx! {
-        <blur sigma=1.>
-            <stack>
-                <backdrop_blur sigma=10.>
-                    <stack>
-                        <positioned><rect fill=Some(Color::new(1.0, 0.0, 0.0, 1.0))/></positioned>
-                        <text size=200.>{"test text"}</text>
-                    </stack>
-                </backdrop_blur>
-                <draggable_rect initial_pos=Vec2::zero() />
-                <draggable_rect initial_pos=Vec2::new(100.0, 0.0) />
-                <draggable_rect initial_pos=Vec2::new(200.0, 0.0) />
-                <draggable_rect initial_pos=Vec2::new(300.0, 0.0) />
-                <draggable_rect initial_pos=Vec2::new(400.0, 0.0) />
-            </stack>
-        </blur>
+        <stack>
+            <backdrop_blur sigma=10.>
+                <stack>
+                    <positioned><rect fill=Some(Color::new(1.0, 0.0, 0.0, 1.0))/></positioned>
+                    <text size=200.>{"test text"}</text>
+                </stack>
+            </backdrop_blur>
+            <draggable_rect initial_pos=Vec2::zero() />
+            <draggable_rect initial_pos=Vec2::new(100.0, 0.0) />
+            <draggable_rect initial_pos=Vec2::new(200.0, 0.0) />
+            <draggable_rect initial_pos=Vec2::new(300.0, 0.0) />
+            <draggable_rect initial_pos=Vec2::new(400.0, 0.0) />
+        </stack>
     }
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,15 @@
-use narui::*;
+use narui::{
+    app,
+    column,
+    flexible,
+    rect_leaf,
+    rsx,
+    rsx_toplevel,
+    widget,
+    Color,
+    Fragment,
+    WidgetContext,
+};
 
 #[widget]
 pub fn top(context: &mut WidgetContext) -> Fragment {

--- a/narui_macros/src/lib.rs
+++ b/narui_macros/src/lib.rs
@@ -69,7 +69,7 @@ fn narui_macros() -> TokenStream {
             let found_crate = found_crate_to_tokens(x);
             quote! { #found_crate::_macros }
         })
-        .and_then(|_| {
+        .or_else::<proc_macro_crate::Error, _>(|_| {
             let found_crate = found_crate_to_tokens(crate_name("narui_macros")?);
             Ok(quote! { #found_crate })
         })
@@ -77,7 +77,7 @@ fn narui_macros() -> TokenStream {
 }
 fn found_crate_to_tokens(x: FoundCrate) -> TokenStream {
     match x {
-        FoundCrate::Itself => quote!(crate),
+        FoundCrate::Itself => quote!(narui),
         FoundCrate::Name(name) => {
             let ident = Ident::new(&name, Span::call_site());
             quote!( #ident )

--- a/narui_widgets/Cargo.toml
+++ b/narui_widgets/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-narui = { path = "../narui_core", package = "narui_core" }
+narui_core = { path = "../narui_core" }
 narui_macros = { path = "../narui_macros" }
 vulkano = { git = "https://github.com/vulkano-rs/vulkano" }
 vulkano-shaders = { git = "https://github.com/vulkano-rs/vulkano" }

--- a/narui_widgets/src/controls.rs
+++ b/narui_widgets/src/controls.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use narui::{re_export::palette::Shade, *};
+use narui_core::{re_export::palette::Shade, *};
 use narui_macros::{rsx, widget};
 
 #[widget]

--- a/narui_widgets/src/fragment.rs
+++ b/narui_widgets/src/fragment.rs
@@ -1,4 +1,4 @@
-use narui::{layout::Transparent, *};
+use narui_core::{layout::Transparent, *};
 use narui_macros::widget;
 
 #[widget]

--- a/narui_widgets/src/input.rs
+++ b/narui_widgets/src/input.rs
@@ -1,5 +1,5 @@
 use crate::{fragment, positioned, stack};
-use narui::{layout::Maximal, *};
+use narui_core::{layout::Maximal, *};
 use narui_macros::{rsx, widget};
 use std::sync::Arc;
 
@@ -20,7 +20,6 @@ pub fn input_leaf(
         },
     }
 }
-
 
 #[widget]
 pub fn input(

--- a/narui_widgets/src/layout.rs
+++ b/narui_widgets/src/layout.rs
@@ -1,4 +1,4 @@
-use narui::{layout::*, re_export::smallvec::smallvec, *};
+use narui_core::{layout::*, re_export::smallvec::smallvec, *};
 use narui_macros::widget;
 
 #[widget]

--- a/narui_widgets/src/rect.rs
+++ b/narui_widgets/src/rect.rs
@@ -1,5 +1,5 @@
 use crate::layout::{positioned, sized, stack};
-use narui::{layout::Maximal, *};
+use narui_core::{layout::Maximal, *};
 use narui_macros::{rsx, widget};
 
 

--- a/narui_widgets/src/subpass.rs
+++ b/narui_widgets/src/subpass.rs
@@ -1,11 +1,10 @@
-use narui::{
+use narui_core::{
     layout::Transparent,
     re_export::smallvec::smallvec,
     CallbackContext,
     ContextEffect,
     ContextMeasure,
     Fragment,
-    FragmentInner,
     Rect,
     SubPassRenderFunction,
     SubPassSetup,

--- a/narui_widgets/src/text.rs
+++ b/narui_widgets/src/text.rs
@@ -1,5 +1,5 @@
 use crate::theme;
-use narui::{
+use narui_core::{
     layout::{layout_trait::LayoutableChildren, BoxConstraints, Layout, Size},
     re_export::glyph_brush::{
         ab_glyph::{Font, ScaleFont},

--- a/narui_widgets/src/theme.rs
+++ b/narui_widgets/src/theme.rs
@@ -1,4 +1,4 @@
-use narui::{re_export::palette::rgb::Rgb, Color};
+use narui_core::{re_export::palette::rgb::Rgb, Color};
 use std::marker::PhantomData;
 
 const fn rgb(red: f32, green: f32, blue: f32) -> Color {


### PR DESCRIPTION
This reworks the macros to
1. Reexport everything they need from narui / narui_core under their own
module and use them in the generated macros.
2. Put everything the widget macro generates into the widget module.

This on the one hand fixes all the macro import issues and makes non star imports
work and on the other hand reduces the global namespace pollution by
putting everything into the generated module.

(Depends on #15 aswell, so merge this after that)