### PR TITLE
do not eagerly acquire new swapchain images

### DIFF
--- a/narui_core/src/vulkano_render/vk_util.rs
+++ b/narui_core/src/vulkano_render/vk_util.rs
@@ -37,7 +37,8 @@ impl VulkanContext {
                     khr_swapchain: true,
                     khr_storage_buffer_storage_class: true,
                     khr_8bit_storage: true,
-                    khr_shader_non_semantic_info: true,
+                    // Comment in if you need shader printf
+                    // khr_shader_non_semantic_info: true,
                     ..(*physical.required_extensions())
                 };
                 Device::new(physical, physical.supported_features(), &device_ext, queue_family).ok()


### PR DESCRIPTION
This seems to break MoltenVK and it is generally unclear if what we were doing here was legal.
Instead of this we should do proper frame pacing, but it seems like most of the vulkan extensions that would make this
better are not available yet. So for now just degrade the latency again.