### PR TITLE
better macos support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ash"
+version = "0.35.2+1.2.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6a491bcad4563b355ac2bb6e3f09d5e1c5d628710c7156e901dad0c416075e"
+dependencies = [
+ "libloading 0.7.0",
+]
+
+[[package]]
+name = "ash-molten"
+version = "0.13.0+1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddc8dfcdf7ba11f085ff7a5cf39165c13c6446159f286da1071514f1a5b6e45"
+dependencies = [
+ "anyhow",
+ "ash 0.35.2+1.2.203",
+ "plist",
+ "serde",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +118,12 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bind_match"
@@ -680,6 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,9 +726,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libloading"
@@ -715,6 +748,15 @@ checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi",
+]
+
+[[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
 ]
 
 [[package]]
@@ -904,6 +946,9 @@ version = "0.1.2"
 dependencies = [
  "ahash",
  "anyhow",
+ "ash 0.33.3+1.2.191",
+ "ash 0.35.2+1.2.203",
+ "ash-molten",
  "crevice",
  "ctor",
  "dashmap",
@@ -1089,6 +1134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1298,20 @@ name = "pkg-config"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c9b1041b4387893b91ee6746cddfc28516aff326a3519fb2adf820932c5e6cb"
+
+[[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time",
+ "xml-rs",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1450,6 +1518,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,7 +1570,7 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -1641,6 +1715,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+dependencies = [
+ "itoa 1.0.3",
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "tinyset"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,7 +1799,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b9901caa88a0d312e9c5bbf000a864798ffc23f689463779275427f1aa84d42"
 dependencies = [
- "ash",
+ "ash 0.33.3+1.2.191",
  "crossbeam-queue",
  "fnv",
  "half",

--- a/narui_core/Cargo.toml
+++ b/narui_core/Cargo.toml
@@ -40,3 +40,8 @@ smallvec = "1.7.0"
 take_mut = "0.2.2"
 tinyset = { version = "0.4.6", default-features = false }
 crevice = "0.8.0"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+ash-molten = { version = "0.13.0+1.1.10", features = ["pre-built"] }
+ash_molten_version = {package = "ash", version = "0.35.2+1.2.203"}
+ash_vulkano_version = {package = "ash", version = "0.33.3+1.2.191"}

--- a/narui_core/src/context/key.rs
+++ b/narui_core/src/context/key.rs
@@ -48,6 +48,7 @@ pub struct KeyMap {
     keys: Vec<KeyMapEntry>,
 }
 
+#[cfg(target_arch = "x86_64")]
 fn find_avx2(data: &[i32], needle: i32) -> Option<usize> {
     use std::arch::x86_64::*;
     let trunc = (data.len() / 8) * 8;
@@ -93,7 +94,7 @@ impl KeyMap {
 
                     #[cfg(not(target_arch = "x86_64"))]
                     {
-                        entry.children_tails.iter().find(|v| *v == tail_packed)
+                        entry.children_tails.iter().position(|v| *v == tail_packed)
                     }
                 }
             };

--- a/narui_core/src/vulkano_render/vk_util.rs
+++ b/narui_core/src/vulkano_render/vk_util.rs
@@ -1,14 +1,24 @@
 use anyhow::{anyhow, Result};
+use std::{
+    ffi::CStr,
+    os::raw::{c_char, c_void},
+};
 
 use std::sync::Arc;
 use vulkano::{
     device::{
         physical::{PhysicalDevice, PhysicalDeviceType},
         Device,
+        DeviceCreationError,
         DeviceExtensions,
         Queue,
     },
-    instance::{debug::*, Instance, InstanceExtensions},
+    instance::{
+        debug::*,
+        loader::{FunctionPointers, Loader},
+        Instance,
+        InstanceExtensions,
+    },
     Version,
 };
 
@@ -19,6 +29,7 @@ pub struct VulkanContext {
     pub queues: Vec<Arc<Queue>>,
 }
 
+#[cfg(not(target_os = "macos"))]
 impl VulkanContext {
     pub fn create() -> Result<Self> {
         let required_extensions = vulkano_win::required_extensions();
@@ -58,6 +69,92 @@ impl VulkanContext {
                 Device::new(physical, physical.supported_features(), &device_ext, queue_family).ok()
             })
             .ok_or_else(|| anyhow!("No physical device found"))?;
+
+        Ok(Self { device, queues: queues.collect() })
+    }
+}
+
+
+#[cfg(target_os = "macos")]
+impl VulkanContext {
+    pub fn create() -> Result<Self> {
+        let required_extensions = vulkano_win::required_extensions();
+        let extensions = InstanceExtensions {
+            khr_surface: true,
+            mvk_macos_surface: true,
+            ext_debug_utils: true,
+            ext_debug_report: true,
+            ..required_extensions
+        };
+
+        struct AshMoltenLoader {
+            staticFn: ash_molten_version::vk::StaticFn,
+        }
+        unsafe impl Loader for AshMoltenLoader {
+            fn get_instance_proc_addr(
+                &self,
+                instance: ash_vulkano_version::vk::Instance,
+                name: *const c_char,
+            ) -> *const c_void {
+                let inner_result = unsafe {
+                    self.staticFn.get_instance_proc_addr(std::mem::transmute(instance), name)
+                };
+                if let Some(result) = inner_result {
+                    result as *const c_void
+                } else {
+                    0 as *const c_void
+                }
+            }
+        }
+
+        let function_pointers: FunctionPointers<Box<dyn Loader + Send + Sync>> =
+            FunctionPointers::new(Box::new(AshMoltenLoader {
+                staticFn: ash_molten::load().static_fn().clone(),
+            }));
+        let instance =
+            Instance::with_loader(function_pointers, None, Version::V1_2, &extensions, None)?;
+        std::mem::forget(DebugCallback::new(
+            &instance,
+            MessageSeverity { error: true, warning: true, information: true, verbose: true },
+            MessageType::all(),
+            |msg| log::info!("{}: {}", msg.layer_prefix.unwrap_or("unknown"), msg.description),
+        ));
+
+        let mut devices_vec: Vec<_> = PhysicalDevice::enumerate(&instance).collect();
+        devices_vec.sort_unstable_by_key(|dev| {
+            if dev.properties().device_type == PhysicalDeviceType::Cpu {
+                1
+            } else {
+                0
+            }
+        });
+        let mut error: Option<DeviceCreationError> = None;
+        let (device, queues) = devices_vec
+            .into_iter()
+            .find_map(|physical| {
+                let queue_family = physical.queue_families().map(|qf| (qf, 0.5)); // All queues have the same priority
+                let device_ext = DeviceExtensions {
+                    khr_swapchain: true,
+                    khr_storage_buffer_storage_class: true,
+                    khr_8bit_storage: true,
+                    // Comment in if you need shader printf
+                    // khr_shader_non_semantic_info: true,
+                    ..(*physical.required_extensions())
+                };
+                match Device::new(
+                    physical,
+                    physical.supported_features(),
+                    &device_ext,
+                    queue_family,
+                ) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        error = Some(e.clone());
+                        None
+                    }
+                }
+            })
+            .ok_or_else(|| anyhow!("No physical device found. Last error was: {:?}", error))?;
 
         Ok(Self { device, queues: queues.collect() })
     }


### PR DESCRIPTION
this adds support for https://github.com/EmbarkStudios/ash-molten and thus makes it unnescessary to have moltenVK installed to use narui on macos